### PR TITLE
chore: rename to kanso-labs/home-assistant-applications and standardize naming

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "devcontainer for add-on repositories",
+  "name": "devcontainer for application repositories",
   "image": "ghcr.io/home-assistant/devcontainer:3-addons",
   "appPort": ["7123:8123", "7357:4357"],
   "postStartCommand": "bash devcontainer_bootstrap",

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -27,11 +27,11 @@ jobs:
         id: changed_files
         uses: tj-actions/changed-files@v47.0.5
 
-      - name: Find add-ons
+      - name: Find applications
         id: addons
         uses: home-assistant/actions/helpers/find-addons@master
 
-      - name: Get changed add-ons
+      - name: Get changed applications
         id: changed_addons
         run: |
           declare -a changed_addons
@@ -50,11 +50,11 @@ jobs:
           changed=$(echo ${changed_addons[@]} | rev | cut -c 2- | rev)
 
           if [[ -n ${changed} ]]; then
-            echo "Changed add-ons: $changed";
+            echo "Changed applications: $changed";
             echo "changed=true" >> $GITHUB_OUTPUT;
             echo "addons=[$changed]" >> $GITHUB_OUTPUT;
           else
-            echo "No add-on had any monitored files changed (${{ env.MONITORED_FILES }})";
+            echo "No application had any monitored files changed (${{ env.MONITORED_FILES }})";
           fi
 
   build:
@@ -73,7 +73,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
-      - name: Get add-on info
+      - name: Get application info
         id: info
         uses: home-assistant/actions/helpers/info@master
         with:

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -1,4 +1,4 @@
-name: Builder
+name: Build
 
 env:
   BUILD_ARGS: '--test'
@@ -15,15 +15,15 @@ on:
 jobs:
   init:
     runs-on: ubuntu-latest
-    name: Initialize
+    name: Detect changed applications
     outputs:
       changed_addons: ${{ steps.changed_addons.outputs.addons }}
       changed: ${{ steps.changed_addons.outputs.changed }}
     steps:
-      - name: Checkout
+      - name: Check out repository
         uses: actions/checkout@v6.0.2
 
-      - name: Get changed files
+      - name: List changed files
         id: changed_files
         uses: tj-actions/changed-files@v47.0.5
 
@@ -31,7 +31,7 @@ jobs:
         id: addons
         uses: home-assistant/actions/helpers/find-addons@master
 
-      - name: Get changed applications
+      - name: Select changed applications
         id: changed_addons
         run: |
           declare -a changed_addons
@@ -70,16 +70,16 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Checkout
+      - name: Check out repository
         uses: actions/checkout@v6.0.2
 
-      - name: Get application info
+      - name: Read application metadata
         id: info
         uses: home-assistant/actions/helpers/info@master
         with:
           path: './${{ matrix.addon }}'
 
-      - name: Check architecture
+      - name: Check architecture support
         id: check
         run: |
           if [[ "${{ steps.info.outputs.image }}" == "null" ]]; then
@@ -96,7 +96,7 @@ jobs:
             echo "build_arch=false" >> $GITHUB_OUTPUT;
           fi
 
-      - name: Login to GitHub Container Registry
+      - name: Log in to GitHub Container Registry
         if: env.BUILD_ARGS != '--test'
         uses: docker/login-action@v3.7.0
         with:
@@ -104,7 +104,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build ${{ matrix.addon }}
+      - name: Build ${{ matrix.addon }} image
         if: steps.check.outputs.build_arch == 'true'
         uses: home-assistant/builder@2026.02.1
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   find:
-    name: Find add-ons
+    name: Find applications
     runs-on: ubuntu-latest
     outputs:
       addons: ${{ steps.addons.outputs.addons_list }}
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
-      - name: Find add-ons
+      - name: Find applications
         id: addons
         uses: home-assistant/actions/helpers/find-addons@master
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       addons: ${{ steps.addons.outputs.addons_list }}
     steps:
-      - name: Checkout
+      - name: Check out repository
         uses: actions/checkout@v6.0.2
 
       - name: Find applications
@@ -32,10 +32,10 @@ jobs:
       matrix:
         path: ${{ fromJson(needs.find.outputs.addons) }}
     steps:
-      - name: Checkout
+      - name: Check out repository
         uses: actions/checkout@v6.0.2
 
-      - name: Lint
+      - name: Run application linter
         uses: frenck/action-addon-linter@v2.21
         with:
           path: './${{ matrix.path }}'

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
       "problemMatcher": []
     },
     {
-      "label": "Start Addon",
+      "label": "Start Application",
       "type": "shell",
       "command": "ha addons stop \"local_${input:addonName}\"; ha addons start \"local_${input:addonName}\"; docker logs --follow \"addon_local_${input:addonName}\"",
       "group": {
@@ -33,7 +33,7 @@
       }
     },
     {
-      "label": "Rebuild and Start Addon",
+      "label": "Rebuild and Start Application",
       "type": "shell",
       "command": "ha addons rebuild \"local_${input:addonName}\"; ha addons start \"local_${input:addonName}\"; docker logs --follow \"addon_local_${input:addonName}\"",
       "group": {
@@ -51,7 +51,7 @@
     {
       "id": "addonName",
       "type": "pickString",
-      "description": "Name of addon (to add your addon to this list, please edit .vscode/tasks.json)",
+      "description": "Name of application (to add your application to this list, please edit .vscode/tasks.json)",
       "options": ["hyperion"]
     }
   ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,23 +2,24 @@
 
 We are open to, and grateful for, any contributions made by the community. By
 contributing to this project, you agree to abide by the
-[code of conduct](https://github.com/kanso-org/hassio-addons/blob/main/CODE_OF_CONDUCT.md).
+[code of conduct](https://github.com/kanso-labs/home-assistant-applications/blob/main/CODE_OF_CONDUCT.md).
 
 ## Reporting Issues and Asking Questions
 
 Before opening an issue, please search the
-[issue tracker](https://github.com/kanso-org/hassio-addons/issues) to make sure
-your issue hasn't already been reported.
+[issue tracker](https://github.com/kanso-labs/home-assistant-applications/issues)
+to make sure your issue hasn't already been reported.
 
 ## Development
 
-Visit the [issue tracker](https://github.com/kanso-org/hassio-addons/issues) to
-find a list of open issues that need attention.
+Visit the
+[issue tracker](https://github.com/kanso-labs/home-assistant-applications/issues)
+to find a list of open issues that need attention.
 
 Fork, then clone the repo:
 
 ```shell
-git clone https://github.com/your-username/hassio-addons.git
+git clone https://github.com/your-username/home-assistant-applications.git
 ```
 
 ### New Features
@@ -30,7 +31,7 @@ that we won't want to accept.
 ## Submitting Changes
 
 - Open a new issue in the
-  [Issue tracker](https://github.com/kanso-org/hassio-addons/issues).
+  [Issue tracker](https://github.com/kanso-labs/home-assistant-applications/issues).
 - Fork the repo.
 - Create a new feature branch based off the `main` branch.
 - Make sure all tests pass and there are no linting errors.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2025 Kanso Org.
+Copyright 2025 Kanso Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the “Software”), to deal in

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Kanso Home Assistant add-on repository
+# Kanso Home Assistant application repository
 
-[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fkanso-labs%2Fhome-assistant-applications)
+[![Open your Home Assistant instance and show the add application repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fkanso-labs%2Fhome-assistant-applications)
 
-## Add-ons
+## Applications
 
-This repository contains the following add-ons
+This repository contains the following applications
 
-### [n8n add-on](./n8n)
+### [n8n application](./n8n)
 
 Flexible AI workflow automation for technical teams.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kanso Home Assistant add-on repository
 
-[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fkanso-org%2Fhassio-addons)
+[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fkanso-labs%2Fhome-assistant-applications)
 
 ## Add-ons
 

--- a/n8n/DOCS.md
+++ b/n8n/DOCS.md
@@ -1,4 +1,4 @@
-# Home Assistant Add-on: n8n
+# Home Assistant Application: n8n
 
 ## How to use
 

--- a/n8n/Dockerfile
+++ b/n8n/Dockerfile
@@ -2,7 +2,7 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
 
-# Install requirements for add-on
+# Install requirements for application
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     bash \
     curl \

--- a/n8n/apparmor.txt
+++ b/n8n/apparmor.txt
@@ -24,7 +24,7 @@ profile example flags=(attach_disconnected,mediate_deleted) {
   /usr/lib/bashio/** ix,
   /tmp/** rwk,
 
-  # Access to options.json and other files within your addon
+  # Access to options.json and other files within your application
   /data/** rw,
 
   # Start new profile for service
@@ -36,7 +36,7 @@ profile example flags=(attach_disconnected,mediate_deleted) {
     # Receive signals from S6-Overlay
     signal (receive) peer=*_example,
 
-    # Access to options.json and other files within your addon
+    # Access to options.json and other files within your application
     /data/** rw,
 
     # Access to mapped volumes specified in config.json
@@ -45,7 +45,7 @@ profile example flags=(attach_disconnected,mediate_deleted) {
     # Access required for service functionality
     # Note: List was built by doing the following:
     # 1. Add what is obviously needed based on what is in the script
-    # 2. Add `complain` as a flag to this profile temporarily and run the addon
+    # 2. Add `complain` as a flag to this profile temporarily and run the application
     # 3. Review the audit log with `journalctl _TRANSPORT="audit" -g 'apparmor="ALLOWED"'` and add other access as needed
     # Remember to remove the `complain` flag when you are done
     /usr/bin/my_program r,

--- a/n8n/build.yaml
+++ b/n8n/build.yaml
@@ -2,7 +2,7 @@ build_from:
   aarch64: 'ghcr.io/home-assistant/aarch64-base-ubuntu:24.04'
   amd64: 'ghcr.io/home-assistant/amd64-base-ubuntu:24.04'
 labels:
-  org.opencontainers.image.title: 'Home Assistant Add-on: n8n'
+  org.opencontainers.image.title: 'Home Assistant Application: n8n'
   org.opencontainers.image.description:
     Flexible AI workflow automation for technical teams. Build with the
     precision of code or the speed of drag-n-drop. Host with on-prem control or

--- a/n8n/build.yaml
+++ b/n8n/build.yaml
@@ -8,5 +8,5 @@ labels:
     precision of code or the speed of drag-n-drop. Host with on-prem control or
     in-the-cloud convenience. n8n gives you more freedom to implement multi-step
     AI agents and integrate apps than any other tool.
-  org.opencontainers.image.source: 'https://github.com/kanso-org/hassio-addons'
+  org.opencontainers.image.source: 'https://github.com/kanso-labs/home-assistant-applications'
   org.opencontainers.image.licenses: 'MIT'

--- a/n8n/config.yaml
+++ b/n8n/config.yaml
@@ -9,7 +9,7 @@ description:
 arch:
   - aarch64
   - amd64
-url: 'https://github.com/kanso-org/hassio-addons/tree/main/n8n'
+url: 'https://github.com/kanso-labs/home-assistant-applications/tree/main/n8n'
 map:
   - type: share
     read_only: false
@@ -24,7 +24,7 @@ schema:
   enable_ssl: bool
   log_level: list(debug|info|warn|error)
   node_function_external_modules: [str]
-image: 'ghcr.io/kanso-org/{arch}-addon-n8n'
+image: 'ghcr.io/kanso-labs/{arch}-addon-n8n'
 ingress: true
 ingress_port: 5678
 panel_icon: 'mdi:diversify'

--- a/n8n/config.yaml
+++ b/n8n/config.yaml
@@ -24,7 +24,7 @@ schema:
   enable_ssl: bool
   log_level: list(debug|info|warn|error)
   node_function_external_modules: [str]
-image: 'ghcr.io/kanso-labs/{arch}-addon-n8n'
+image: 'ghcr.io/kanso-labs/home-assistant-application-n8n-{arch}'
 ingress: true
 ingress_port: 5678
 panel_icon: 'mdi:diversify'

--- a/n8n/rootfs/etc/services.d/n8n/finish
+++ b/n8n/rootfs/etc/services.d/n8n/finish
@@ -3,7 +3,7 @@
 declare APP_EXIT_CODE=${1}
 
 if [[ "${APP_EXIT_CODE}" -ne 0 ]] && [[ "${APP_EXIT_CODE}" -ne 256 ]]; then
-  bashio::log.warning "Halt add-on with exit code ${APP_EXIT_CODE}"
+  bashio::log.warning "Halt application with exit code ${APP_EXIT_CODE}"
   echo "${APP_EXIT_CODE}" > /run/s6-linux-init-container-results/exitcode
   exec /run/s6/basedir/bin/halt
 fi

--- a/n8n/rootfs/usr/src/n8n/package.json
+++ b/n8n/rootfs/usr/src/n8n/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hassio-addon-n8n",
+  "name": "home-assistant-application-n8n",
   "version": "1.0.0",
   "private": true,
   "dependencies": {

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,4 @@
 # https://developers.home-assistant.io/docs/add-ons/repository#repository-configuration
 name: Kanso Home Assistant add-on repository
 url: 'https://github.com/kanso-labs/home-assistant-applications'
-maintainer: Kanso Labs <kanso-org@rodrigosn.com>
+maintainer: Kanso Labs <kanso.labs.org@gmail.com>

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,4 @@
-# https://developers.home-assistant.io/docs/add-ons/repository#repository-configuration
-name: Kanso Home Assistant add-on repository
+# https://developers.home-assistant.io/docs/apps/repository/#repository-configuration
+name: Kanso Labs Home Assistant applications repository
 url: 'https://github.com/kanso-labs/home-assistant-applications'
 maintainer: Kanso Labs <kanso.labs.org@gmail.com>

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,4 @@
 # https://developers.home-assistant.io/docs/add-ons/repository#repository-configuration
 name: Kanso Home Assistant add-on repository
-url: 'https://github.com/kanso-org/hassio-addons'
-maintainer: Kanso Org. <kanso-org@rodrigosn.com>
+url: 'https://github.com/kanso-labs/home-assistant-applications'
+maintainer: Kanso Labs <kanso-org@rodrigosn.com>


### PR DESCRIPTION
## Summary

Fixes the n8n app being unpullable by Home Assistant, caused by `n8n/config.yaml` naming the retired `kanso-org` container namespace after the org rename, by realigning every identifier in the repository with `kanso-labs/home-assistant-applications`.

Before this change the config named a namespace nothing publishes to, so Home Assistant had no image to pull. It now names the namespace CI actually pushes to.

The rest of the change carries the rename the rest of the way: dead links, the old organization name, the maintainer address, and Home Assistant's retired ["add-on" terminology](https://developers.home-assistant.io/docs/apps).

## Problem

The org and repo were renamed to `kanso-labs/home-assistant-applications`, but every reference inside the repository still pointed at `kanso-org/hassio-addons`. That org is gone — `GET /orgs/kanso-org` returns 404 — so every one of those links is dead.

Most of that is cosmetic: documentation links and the install badge. One was not.

`n8n/config.yaml` told Home Assistant to pull `ghcr.io/kanso-org/{arch}-addon-n8n`, while `.github/workflows/builder.yaml` publishes to `ghcr.io/${{ github.repository_owner }}` — which resolves to `kanso-labs`. The two sides named different namespaces, and the one users pull from was the empty one.

## Evidence

Anonymous manifest request against both namespaces for tag `1.0.0`:

```
ghcr.io/kanso-org/amd64-addon-n8n:1.0.0    HTTP 403
ghcr.io/kanso-labs/amd64-addon-n8n:1.0.0   HTTP 200
```

The image exists and is public under the new namespace. Nothing is reachable under the old one.

## Solution

Four things carried the old identity. Each is now aligned with the repository's current name.

**Repository paths.** Every link now points at the live repo — the `url` fields in `repository.yaml` and `n8n/config.yaml`, the image source label in `n8n/build.yaml`, the install badge in `README.md`, and the issue-tracker and clone references in `CONTRIBUTING.md`.

`builder.yaml` is untouched. It derives the namespace from `github.repository_owner`, so it followed the rename on its own; `config.yaml` was the side that drifted.

`CONTRIBUTING.md` was re-wrapped by Prettier, which the repo configures with `proseWrap: always`. That is why its diff is noisier than link-only edits should be.

**Container image naming.** Every app in this repository now publishes under one convention:

| | |
|---|---|
| Old | `ghcr.io/kanso-labs/{arch}-addon-n8n` |
| New | `ghcr.io/kanso-labs/home-assistant-application-n8n-{arch}` |
| Convention | `ghcr.io/kanso-labs/home-assistant-application-<app_name>-{arch}` |

Moving `{arch}` from prefix to suffix is safe on both sides. Supervisor resolves the image with `config[ATTR_IMAGE].format(arch=arch)` — a plain `str.format`, so the placeholder works in any position. `builder.yaml` derives the slug with `cut -d'/' -f3`, which still yields the whole slug.

**Organization identity.** The maintainer address in `repository.yaml` moved to `kanso.labs.org@gmail.com`, and the display name and `LICENSE.md` copyright holder both now read `Kanso Labs`. That address is the only email in the repository — `CODE_OF_CONDUCT.md` routes reports to a labelled GitHub issue instead.

**Terminology.** Home Assistant renamed add-ons to apps, so every user-visible string that said "add-on" now says "application": repository and n8n titles, README headings, the OCI image title label, workflow step names and log output, VS Code task labels, and the internal npm package name. The doc comment in `repository.yaml` now points at `docs/apps/repository`, which carries the same `#repository-configuration` anchor.

Home Assistant's own API surface keeps the old spelling, because renaming it would break the build:

- the `--addon` flag passed to `home-assistant/builder`
- `home-assistant/actions/helpers/find-addons` and its `addons_list` output
- `frenck/action-addon-linter`
- the `ha addons` CLI and the `addon_local_*` container name
- `bashio::addon.ingress_url` and `ingress_entry`
- `/mnt/supervisor/addons/local` and the `devcontainer:3-addons` image tag
- the `supervisor_add_addon_repository` my.home-assistant.io redirect

Internal workflow variables (`changed_addons`, `matrix.addon`) also keep their names — renaming them is churn with no user-visible effect.

**Workflow naming.** The two workflows named things three different ways: nouns (`Checkout`, `Login`, `Builder`), vague verbs (`Get application info`), and one bare `Initialize` that said nothing about what the job does. Three rules now apply.

- A workflow name is a noun naming the pipeline.
- A job name is an imperative verb phrase, with matrix values appended.
- A step name is an imperative verb phrase in sentence case.

Job ids, step ids, and matrix keys keep their names, for the same reason as above. Renaming the `Builder` workflow to `Build` does change the check names GitHub shows on pull requests, so this PR's own check history carries both spellings — `main` has no branch protection, so no required-check binding needs updating.

## Operational notes

Two things to know before merging.

The `version` in `n8n/config.yaml` is deliberately unchanged at `1.0.0`. Home Assistant compares that string to decide whether an update exists, so an already-installed instance will not re-pull despite the image path changing. Anyone running n8n from the old path needs to reinstall or rebuild.

New packages publish on the first build after this merges to `main`. Until that build finishes, the app cannot be freshly installed under the new name. The old `amd64-addon-n8n` and `aarch64-addon-n8n` packages are orphaned by this and can be deleted from GHCR once the change has settled.

## Left for the author

One unrelated bug turned up during the sweep and was not touched, since it has nothing to do with the rename: `.vscode/tasks.json` lists `"options": ["hyperion"]` in its app picker, which should be `["n8n"]`.

## Rollback Plan

Revert via GitHub's Revert button. No migrations and no data changes.

Do not delete the old GHCR packages until the change has settled — a revert only resolves to the old image name while those packages still exist.

## Test plan

**Verifiable by agent before merging**

- [x] `grep` across the tree for `kanso-org`, `kanso-org%2F`, `/hassio-addons`, and `Kanso Org` returns no matches
- [x] Every surviving `addon` string is Home Assistant API surface or an internal workflow variable, enumerated in Solution above
- [x] `prettier --check` passes on all changed files
- [x] `ghcr.io/kanso-labs/amd64-addon-n8n:1.0.0` returns a manifest (HTTP 200); the old `kanso-org` path returns HTTP 403
- [x] The amd64 `--test` build passed under the new image name ([run 31502757860](https://github.com/kanso-labs/home-assistant-applications/actions/runs/31502757860)), proving the builder accepts `{arch}` as a suffix
- [ ] The full builder and lint runs go green on the final commit

**Cannot be verified before merge**

- [ ] The aarch64 `--test` build completing — QEMU-emulated and very slow, exercising the same code path as amd64, which passed
- [ ] Adding the repository to a live Home Assistant instance and installing n8n from the new image path — requires a running Supervisor instance, and the new package does not exist until the first post-merge build on `main`
- [ ] Confirming the install badge opens the add-repository dialog prefilled with the new URL — requires a browser session signed in to a Home Assistant instance
