### PR TITLE
fix(n8n): take backups cold, stream ingress, and restore local development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,24 +1,38 @@
 {
   "appPort": ["7123:8123", "7357:4357"],
   "containerEnv": {
+    "SUPERVISOR_CHANNEL": "beta",
     "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"
   },
   "customizations": {
     "vscode": {
-      "extensions": ["esbenp.prettier-vscode", "timonwong.shellcheck"]
+      "extensions": ["esbenp.prettier-vscode", "timonwong.shellcheck"],
+      "settings": {
+        "editor.formatOnPaste": false,
+        "editor.formatOnSave": true,
+        "editor.formatOnType": true,
+        "files.trimTrailingWhitespace": true,
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "terminal.integrated.profiles.linux": {
+          "zsh": {
+            "path": "/usr/bin/zsh"
+          }
+        }
+      }
     }
   },
-  "features": {
-    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
-  },
-  "image": "ghcr.io/home-assistant/devcontainer:3-addons",
+  "image": "ghcr.io/home-assistant/devcontainer:5-apps",
   "mounts": [
     "type=volume,target=/var/lib/docker",
-    "type=volume,target=/mnt/supervisor"
+    "type=volume,target=/var/lib/containerd",
+    "type=volume,target=/mnt/supervisor",
+    "type=tmpfs,target=/tmp"
   ],
-  "name": "devcontainer for application repositories",
+  "name": "Kanso Labs devcontainer for applications repositories",
+  "overrideCommand": false,
   "postStartCommand": "bash devcontainer_bootstrap",
+  "remoteUser": "vscode",
   "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
-  "workspaceFolder": "/mnt/supervisor/addons/local/${localWorkspaceFolderBasename}",
+  "workspaceFolder": "/mnt/supervisor/apps/local/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind,consistency=cached"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,8 @@
 {
-  "name": "devcontainer for application repositories",
-  "image": "ghcr.io/home-assistant/devcontainer:3-addons",
   "appPort": ["7123:8123", "7357:4357"],
-  "postStartCommand": "bash devcontainer_bootstrap",
-  "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
   "containerEnv": {
     "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"
   },
-  "workspaceFolder": "/mnt/supervisor/addons/local/${localWorkspaceFolderBasename}",
-  "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind,consistency=cached",
   "customizations": {
     "vscode": {
       "extensions": ["esbenp.prettier-vscode", "timonwong.shellcheck"]
@@ -17,8 +11,14 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
+  "image": "ghcr.io/home-assistant/devcontainer:3-addons",
   "mounts": [
     "type=volume,target=/var/lib/docker",
     "type=volume,target=/mnt/supervisor"
-  ]
+  ],
+  "name": "devcontainer for application repositories",
+  "postStartCommand": "bash devcontainer_bootstrap",
+  "runArgs": ["-e", "GIT_EDITOR=code --wait", "--privileged"],
+  "workspaceFolder": "/mnt/supervisor/addons/local/${localWorkspaceFolderBasename}",
+  "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind,consistency=cached"
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,10 +4,8 @@
     {
       "customType": "regex",
       "datasourceTemplate": "docker",
-      "managerFilePatterns": ["/build.yaml$/"],
-      "matchStrings": [
-        "(?:aarch64|amd64|armhf|armv7|i386):\\s*'(?<depName>ghcr\\.io\\/home-assistant\\/[^:]+):(?<currentValue>[^']+)'"
-      ]
+      "managerFilePatterns": ["/Dockerfile$/"],
+      "matchStrings": ["ARG BUILD_FROM=(?<depName>.*?):(?<currentValue>.*?)\\s"]
     }
   ],
   "extends": ["config:recommended"],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -52,7 +52,7 @@
       "id": "addonName",
       "type": "pickString",
       "description": "Name of application (to add your application to this list, please edit .vscode/tasks.json)",
-      "options": ["hyperion"]
+      "options": ["n8n"]
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,58 +1,72 @@
 {
-  "version": "2.0.0",
+  "inputs": [
+    {
+      "description": "Name of application (to add your application to this list, please edit .vscode/tasks.json)",
+      "id": "appName",
+      "options": ["n8n"],
+      "type": "pickString"
+    }
+  ],
   "tasks": [
     {
-      "label": "Start Home Assistant",
-      "type": "shell",
       "command": "supervisor_run",
       "group": {
-        "kind": "test",
-        "isDefault": true
+        "isDefault": true,
+        "kind": "test"
       },
+      "label": "Start Home Assistant",
       "presentation": {
-        "reveal": "always",
-        "panel": "new"
+        "panel": "new",
+        "reveal": "always"
       },
-      "problemMatcher": []
+      "problemMatcher": [],
+      "type": "shell"
     },
     {
-      "label": "Start Application",
-      "type": "shell",
-      "command": "ha addons stop \"local_${input:addonName}\"; ha addons start \"local_${input:addonName}\"; docker logs --follow \"addon_local_${input:addonName}\"",
+      "command": "ha apps install \"local_${input:appName}\"",
       "group": {
-        "kind": "test",
-        "isDefault": false
+        "isDefault": false,
+        "kind": "test"
       },
+      "label": "Install application",
       "presentation": {
-        "reveal": "always",
-        "panel": "new"
+        "panel": "new",
+        "reveal": "always"
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "command": "ha apps stop \"local_${input:appName}\"; ha apps start \"local_${input:appName}\"; ha apps logs -f \"local_${input:appName}\"",
+      "group": {
+        "isDefault": false,
+        "kind": "test"
+      },
+      "label": "Start application",
+      "presentation": {
+        "panel": "new",
+        "reveal": "always"
       },
       "problemMatcher": [],
       "runOptions": {
         "reevaluateOnRerun": false
-      }
+      },
+      "type": "shell"
     },
     {
-      "label": "Rebuild and Start Application",
-      "type": "shell",
-      "command": "ha addons rebuild \"local_${input:addonName}\"; ha addons start \"local_${input:addonName}\"; docker logs --follow \"addon_local_${input:addonName}\"",
+      "command": "ha apps rebuild --force \"local_${input:appName}\"; ha apps start \"local_${input:appName}\"; ha apps logs -f \"local_${input:appName}\"",
       "group": {
-        "kind": "test",
-        "isDefault": false
+        "isDefault": false,
+        "kind": "test"
       },
+      "label": "Rebuild and start application",
       "presentation": {
-        "reveal": "always",
-        "panel": "new"
+        "panel": "new",
+        "reveal": "always"
       },
-      "problemMatcher": []
+      "problemMatcher": [],
+      "type": "shell"
     }
   ],
-  "inputs": [
-    {
-      "id": "addonName",
-      "type": "pickString",
-      "description": "Name of application (to add your application to this list, please edit .vscode/tasks.json)",
-      "options": ["n8n"]
-    }
-  ]
+  "version": "2.0.0"
 }

--- a/n8n/CHANGELOG.md
+++ b/n8n/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to
 - Renovate tracks the base image again. Its rule still pointed at `build.yaml`,
   which no longer exists, so nothing was watching the `BUILD_FROM` default in
   the Dockerfile that replaced it.
+- The local development environment works again. The VS Code tasks and the
+  devcontainer both targeted the retired add-on paths and CLI, so neither the
+  workspace mount nor the install and rebuild tasks resolved.
 
 ### Removed
 

--- a/n8n/CHANGELOG.md
+++ b/n8n/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to
 
 ### Changed
 
+- Backups are now taken cold, so Home Assistant stops n8n for the duration
+  rather than snapshotting a SQLite database that is being written to. The app
+  is briefly unavailable while a backup runs.
+- Ingress responses are now streamed, so the editor's live execution updates
+  reach the browser as they happen instead of being buffered.
 - The published image is now the generic multi-architecture name
   `ghcr.io/kanso-labs/home-assistant-application-n8n`, replacing the
   per-architecture `{arch}` reference.

--- a/n8n/CHANGELOG.md
+++ b/n8n/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to
   a default `BUILD_FROM` so the build no longer depends on Supervisor supplying
   one.
 
+### Fixed
+
+- Renovate tracks the base image again. Its rule still pointed at `build.yaml`,
+  which no longer exists, so nothing was watching the `BUILD_FROM` default in
+  the Dockerfile that replaced it.
+
 ### Removed
 
 - `build.yaml`, which Home Assistant deprecated. Its base image and OCI labels

--- a/n8n/CHANGELOG.md
+++ b/n8n/CHANGELOG.md
@@ -8,11 +8,19 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- The log level and external module options now have names and descriptions in
+  English and Brazilian Portuguese, so the configuration screen no longer shows
+  them as raw keys.
+
 ### Changed
 
 - Backups are now taken cold, so Home Assistant stops n8n for the duration
   rather than snapshotting a SQLite database that is being written to. The app
   is briefly unavailable while a backup runs.
+- `/share` is now mapped read-only. n8n keeps its own state in `/data`, so the
+  write access it previously held was never needed.
 - Ingress responses are now streamed, so the editor's live execution updates
   reach the browser as they happen instead of being buffered.
 - The published image is now the generic multi-architecture name

--- a/n8n/config.yaml
+++ b/n8n/config.yaml
@@ -27,4 +27,6 @@ schema:
 image: 'ghcr.io/kanso-labs/home-assistant-application-n8n'
 ingress: true
 ingress_port: 5678
+ingress_stream: true
 panel_icon: 'mdi:diversify'
+backup: cold

--- a/n8n/config.yaml
+++ b/n8n/config.yaml
@@ -1,32 +1,32 @@
-name: n8n
-version: '1.0.0'
-slug: n8n
+arch:
+  - aarch64
+  - amd64
+backup: cold
 description:
   Flexible AI workflow automation for technical teams. Build with the precision
   of code or the speed of drag-n-drop. Host with on-prem control or in-the-cloud
   convenience. n8n gives you more freedom to implement multi-step AI agents and
   integrate apps than any other tool.
-arch:
-  - aarch64
-  - amd64
-url: 'https://github.com/kanso-labs/home-assistant-applications/tree/main/n8n'
-map:
-  - type: share
-    read_only: false
-init: false
-options:
-  enable_task_runners: false
-  enable_ssl: false
-  log_level: info
-  node_function_external_modules: []
-schema:
-  enable_task_runners: bool
-  enable_ssl: bool
-  log_level: list(debug|info|warn|error)
-  node_function_external_modules: [str]
 image: 'ghcr.io/kanso-labs/home-assistant-application-n8n'
 ingress: true
 ingress_port: 5678
 ingress_stream: true
+init: false
+map:
+  - read_only: false
+    type: share
+name: n8n
+options:
+  enable_ssl: false
+  enable_task_runners: false
+  log_level: info
+  node_function_external_modules: []
 panel_icon: 'mdi:diversify'
-backup: cold
+schema:
+  enable_ssl: bool
+  enable_task_runners: bool
+  log_level: list(debug|info|warn|error)
+  node_function_external_modules: [str]
+slug: n8n
+url: 'https://github.com/kanso-labs/home-assistant-applications/tree/main/n8n'
+version: '1.0.0'

--- a/n8n/config.yaml
+++ b/n8n/config.yaml
@@ -13,7 +13,7 @@ ingress_port: 5678
 ingress_stream: true
 init: false
 map:
-  - read_only: false
+  - read_only: true
     type: share
 name: n8n
 options:

--- a/n8n/translations/en.yaml
+++ b/n8n/translations/en.yaml
@@ -1,9 +1,9 @@
 configuration:
+  enable_ssl:
+    description: Enable SSL for the n8n instance.
+    name: Enable SSL
   enable_task_runners:
-    name: Enable task runners
     description: >
       The task runner feature consists of three components: a task runner, a
       task broker, and a task requester.
-  enable_ssl:
-    name: Enable SSL
-    description: Enable SSL for the n8n instance.
+    name: Enable task runners

--- a/n8n/translations/en.yaml
+++ b/n8n/translations/en.yaml
@@ -7,3 +7,9 @@ configuration:
       The task runner feature consists of three components: a task runner, a
       task broker, and a task requester.
     name: Enable task runners
+  log_level:
+    description: How much detail n8n writes to its log.
+    name: Log level
+  node_function_external_modules:
+    description: npm modules that Code nodes are allowed to import.
+    name: External modules for Code nodes

--- a/n8n/translations/pt-BR.yaml
+++ b/n8n/translations/pt-BR.yaml
@@ -7,3 +7,9 @@ configuration:
       A funcionalidade de task runners consiste em três componentes: um task
       runner, um task broker e um task requester.
     name: Habilitar task runners
+  log_level:
+    description: Quanto detalhe o n8n registra no log.
+    name: Nível de log
+  node_function_external_modules:
+    description: Módulos npm que os nós Code podem importar.
+    name: Módulos externos para nós Code

--- a/n8n/translations/pt-BR.yaml
+++ b/n8n/translations/pt-BR.yaml
@@ -1,9 +1,9 @@
 configuration:
+  enable_ssl:
+    description: Habilitar SSL para a instância do n8n.
+    name: Habilitar SSL
   enable_task_runners:
-    name: Habilitar task runners
     description: >
       A funcionalidade de task runners consiste em três componentes: um task
       runner, um task broker e um task requester.
-  enable_ssl:
-    name: Habilitar SSL
-    description: Habilitar SSL para a instância do n8n.
+    name: Habilitar task runners

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,4 @@
 # https://developers.home-assistant.io/docs/apps/repository/#repository-configuration
+maintainer: Kanso Labs <kanso.labs.org@gmail.com>
 name: Kanso Labs Home Assistant applications repository
 url: 'https://github.com/kanso-labs/home-assistant-applications'
-maintainer: Kanso Labs <kanso.labs.org@gmail.com>


### PR DESCRIPTION
## Summary

Fixes n8n backups being able to capture a corrupt SQLite database, caused by Home Assistant's default of snapshotting `/data` while the app keeps writing to it, by taking backups cold instead.

Before this change a backup ran against a live database and could restore as an unusable file — a failure nobody discovers until they actually need the backup. Backups now stop the app first.

Three smaller items ride along from the same audit against the [apps documentation](https://developers.home-assistant.io/docs/apps), including one regression [#48](https://github.com/kanso-labs/home-assistant-applications/pull/48) introduced.

## Problem

**Backups could produce an unusable database.** `backup` defaults to `hot`, so Supervisor snapshots `/data` without stopping the app. n8n points `N8N_USER_FOLDER` at `/data` and keeps its state in SQLite, which means a backup taken while a workflow is running captures `database.sqlite` mid-write.

**Renovate stopped watching the base image.** The custom manager matched `/build.yaml$/`, and [#48](https://github.com/kanso-labs/home-assistant-applications/pull/48) deleted that file when its contents moved into the Dockerfile. Since then the rule has matched no file at all, so the base image pin has been drifting silently.

**Ingress responses were buffered.** `ingress_stream` defaults to `false`, and the n8n editor uses a push connection for live execution updates.

**`/share` was mapped writable without needing to be.** n8n keeps its own state in `/data`, so nothing it does requires writing to `/share`, and the [security page](https://developers.home-assistant.io/docs/apps/security) asks for read-only mappings where writes are not needed.

**Half the options showed as raw keys.** The schema declares four, but only two had a name and description, so `log_level` and `node_function_external_modules` rendered untranslated in the configuration screen in both languages.

**Local development did not work at all.** The setup still targeted add-ons, which Home Assistant retired. The task picker offered `hyperion`, left over from whatever scaffolding this was copied from, and every task called the `ha addons` CLI. The devcontainer mounted the workspace at `/mnt/supervisor/addons/local`, a path that no longer exists.

## Solution

**Backups now halt the app.** `backup: cold` trades availability during a backup for a consistent snapshot.

**Renovate follows the base image again.** The custom manager now matches the `ARG BUILD_FROM` default in the Dockerfile, which is where the base image has lived since #48. This mirrors what the upstream `hassio-addons` repositories do.

**Ingress streams, and `/share` is read-only.** `ingress_stream: true`, and the share mapping drops the write access it never used.

**Every option is translated.** All four now carry a name and description in English and Brazilian Portuguese.

**Local development follows [apps-example](https://github.com/home-assistant/apps-example) again.** Every task calls `ha apps` rather than `ha addons`, and follows logs through `ha apps logs -f` instead of reaching past the CLI to `docker logs` on a container name the app no longer has. An install task joins the existing start and rebuild ones, and rebuild passes `--force`.

The devcontainer moves to the `devcontainer:5-apps` image and mounts the workspace under `/mnt/supervisor/apps/local`. It picks up the reference's editor settings, zsh profile, and containerd and tmp mounts, and drops the `docker-outside-of-docker` feature that the new image already provides.

**Configuration keys are ordered by name** across `n8n/config.yaml`, `repository.yaml`, `.devcontainer/devcontainer.json`, and both translation files. `.prettierrc` and `.github/renovate.json` were already sorted, so this brings the rest in line rather than inventing a convention.

Three files are deliberately left unsorted, because order carries meaning in them:

- The workflows, where step order is execution order.
- `n8n/CHANGELOG.md`, which is chronological.
- `n8n/rootfs/usr/src/n8n/package.json`, where the npm ecosystem expects `name` and `version` first.

## Design Decisions

| Decision | Context |
| --- | --- |
| Cold backups rather than `backup_pre` / `backup_post` | A hot snapshot is only safe if the database can be quiesced first, and n8n exposes no simple command to do that. Cold backups are the option that actually guarantees consistency. The cost is real: n8n is stopped for the duration of every backup, so it is briefly unreachable and scheduled workflows do not fire in that window. |
| Alphabetical key ordering | This diverges from `home-assistant/apps-example`, which puts `name`, `version`, and `slug` first. It is a repository-owner preference applied deliberately, not a drift away from the reference. |
| Prose says "application" where the reference says "app" | Task labels and descriptions match the terminology used everywhere else in this repository. The `ha apps` command keeps Home Assistant's own spelling, since that is its CLI rather than our wording. |
| The reference's trailing comma is not copied | `apps-example`'s `options` array ends `["example",]`. VS Code parses `tasks.json` as JSONC and tolerates it, but it is not valid JSON and any strict parser rejects it. |

## Rollback Plan

Revert via GitHub's Revert button. No migrations and no data changes.

Reverting restores hot backups, so any backup taken afterwards carries the original corruption risk again.

## Test plan

**Verifiable by agent before merging**

- [x] `prettier --check` passes on every changed file
- [x] All three changed JSON files parse as strict JSON, including the one the reference would have broken
- [x] The `config.yaml` and translation diffs are key reordering plus two added keys, confirmed by reading the diff rather than the file
- [x] No reference to the retired add-on CLI or paths survives in `.vscode` or `.devcontainer`
- [x] Every option in the schema has a name and description in both translation files, with no extras in either — checked by comparing the two key sets rather than by eye

**Cannot be verified before merge**

- [ ] A cold backup produces a restorable SQLite database — requires a running Supervisor instance with the application installed and a workflow executing during the backup
- [ ] Ingress streaming changes the editor's live-update behaviour — same requirement, and the symptom is only visible with a workflow running
- [ ] Renovate's retargeted rule matches the Dockerfile — cannot be confirmed until Renovate next runs and either opens a base image pull request or declines to
- [ ] The devcontainer builds and the tasks run — requires opening the repository in a devcontainer, and the `ha apps` verb needs a Supervisor recent enough to have it
