### PR TITLE
docs: record the image naming convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,37 @@ means updating every `needs.*` and `steps.*` reference for no visible benefit.
 `build.yaml` matches its own filename in a regular expression, so renaming
 either build workflow means updating that pattern too.
 
+### Image naming
+
+An application's `image:` is the generic multi-architecture name, with no
+`{arch}` placeholder in it:
+
+```yaml
+image: 'ghcr.io/kanso-labs/home-assistant-application-<application>'
+```
+
+Home Assistant calls that the preferred form, and it is the only name the
+Supervisor pulls. It resolves because the build publishes a multi-architecture
+manifest under it.
+
+Underneath that manifest sit one image per architecture, and **the architecture
+goes at the front**:
+
+| Published                                                   | What it is              |
+| ----------------------------------------------------------- | ----------------------- |
+| `ghcr.io/kanso-labs/home-assistant-application-n8n`         | manifest, what HA pulls |
+| `ghcr.io/kanso-labs/amd64-home-assistant-application-n8n`   | amd64 image             |
+| `ghcr.io/kanso-labs/aarch64-home-assistant-application-n8n` | aarch64 image           |
+
+That prefix is not a choice. `prepare-multi-arch-matrix` composes it as
+`{registry}/{arch}-{image}`, with no input to change the order, and it matches
+what Home Assistant does across its own images — `amd64-base-ubuntu`,
+`aarch64-base-python`. Only the trailing part comes from `image:`.
+
+So if an application ever needs the legacy per-architecture reference rather
+than the manifest, it is `{arch}-<application>` and never
+`<application>-{arch}`.
+
 ## Submitting Changes
 
 - Open a new issue in the


### PR DESCRIPTION
## Summary

Records how published images are named, so the architecture prefix stops being something you discover by looking at the registry.

Nothing about the images changes here. They already follow this convention — it just was not written down anywhere.

## Problem

The per-architecture images publish as `amd64-home-assistant-application-n8n`, architecture first, and no file in this repository said so.

That gap already cost something. An earlier change adopted a suffix form, `home-assistant-application-n8n-{arch}`, on the assumption that the naming was ours to choose. It is not, and the assumption survived until the images were actually published and inspected.

## Solution

`CONTRIBUTING.md` gains an "Image naming" section beside the existing "Workflow naming" one, recording three things.

- An application's `image:` is the generic multi-architecture name, with no `{arch}` placeholder. It is the only name Supervisor pulls, and it resolves because the build publishes a manifest under it.
- Underneath that manifest sit one image per architecture, named `{arch}-<image>`.
- An application needing the legacy per-architecture reference rather than the manifest writes `{arch}-<application>`, never `<application>-{arch}`.

The prefix is not a choice. `prepare-multi-arch-matrix` composes each name as `${REGISTRY_PREFIX}/${arch}-${IMAGE_NAME}` with no input to change the order, and only the trailing part comes from `image:`. It also matches what Home Assistant does across its own images, such as `amd64-base-ubuntu` and `aarch64-base-python`.

## Test plan

**Verifiable by agent before merging**

- [x] `prettier --check` passes
- [x] No tracked file references a suffix architecture form — the only matches are in untracked local scratch
- [x] The documented shape matches what is actually published: `home-assistant-application-n8n` resolves as an index over `arm64` and `amd64`, with `amd64-` and `aarch64-` prefixed images beneath it

Nothing here runs, so there is nothing that needs a live environment to confirm.
