### PR TITLE
docs: add agent guidance for building new applications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,276 @@
+# AGENTS.md
+
+Guidance for coding agents working in this repository.
+
+## What this is
+
+A Home Assistant **app repository**. Home Assistant calls these apps; they were
+called add-ons until 2026, and both names still appear in its own tooling. This
+repository says "application" in everything it writes, and keeps Home
+Assistant's spelling wherever its API surface demands it.
+
+Every top-level directory containing a `config.yaml` is one application. Home
+Assistant reads `repository.yaml` to discover the repository, then each
+`config.yaml` to discover what it can install.
+
+The authorities, in the order you should trust them:
+
+1. **[Home Assistant Supervisor](https://github.com/home-assistant/supervisor)**
+   — the code that actually runs these. When the documentation and the source
+   disagree, the source is right.
+2. **[home-assistant/apps-example](https://github.com/home-assistant/apps-example)**
+   — the reference implementation. Match its shape unless there is a reason not
+   to, and record the reason.
+3. **[The apps documentation](https://developers.home-assistant.io/docs/apps)**
+   — correct in the large, occasionally behind in the details.
+4. **`frenck/action-addon-linter`** — not an authority, but it is the gate. It
+   has had no release since 2025-11 and rejects things Supervisor accepts. See
+   Traps.
+
+## Adding an application
+
+### 1. Start from existing packaging
+
+Someone has usually packaged it already, most often under
+[hassio-addons](https://github.com/orgs/hassio-addons/repositories) as
+`app-<name>` or `addon-<name>`. Port that rather than inventing one: the service
+scripts, icon, and logo are all reusable, and it is MIT licensed.
+
+Credit the original in the application's `DOCS.md`, and credit the upstream
+project separately — the packaging and the software it packages have different
+authors and usually different licences.
+
+Do not copy the pinned version. Check what the project has actually released;
+the community packaging is often behind, which is usually why an application is
+being added here at all.
+
+### 2. Create the directory
+
+Match what the existing applications have:
+
+```
+<slug>/
+├── CHANGELOG.md      Keep a Changelog format
+├── DOCS.md           installation, configuration, storage, backups, credits
+├── Dockerfile
+├── README.md         short intro, shown in the store
+├── config.yaml
+├── icon.png          square, 128×128
+├── logo.png          landscape, around 250×100
+├── rootfs/           s6 service definition
+└── translations/     en.yaml, pt-BR.yaml
+```
+
+`README.md` and `DOCS.md` are different documents. The store shows the README as
+the intro and DOCS as the full documentation.
+
+### 3. `config.yaml`
+
+Keys are ordered by name. Required: `name`, `version`, `slug`, `description`,
+`arch`.
+
+```yaml
+arch:
+  - aarch64
+  - amd64
+backup: cold
+image: 'ghcr.io/kanso-labs/home-assistant-application-<slug>'
+init: false
+version: '1.0.0' # x-release-please-version
+```
+
+- **`image`** is the generic multi-architecture name, with no `{arch}`
+  placeholder. See "Image naming" below.
+- **`init: false`** because the base image supplies s6-overlay.
+- **`backup: cold`** for anything storing state in SQLite, which is most of
+  them. A hot backup copies the database while it is being written and can
+  restore into a corrupt file.
+- **`version`** starts at `1.0.0` and is never edited by hand afterwards. The
+  annotation is load-bearing; see Releases.
+
+Map the least you can. Grant write access only where the application actually
+writes, and omit a mapping entirely when it is never touched. Radarr and Sonarr
+need `/media` and `/share` because organising files is their job. Prowlarr
+manages indexer definitions and gets neither, even though its upstream packaging
+maps both.
+
+### 4. `Dockerfile`
+
+```dockerfile
+# https://developers.home-assistant.io/docs/apps/configuration#app-dockerfile
+ARG BUILD_FROM=ghcr.io/home-assistant/base:3.24
+FROM ${BUILD_FROM}
+
+ARG BUILD_ARCH=amd64
+ARG BUILD_VERSION=dev
+# renovate: datasource=github-releases depName=<Org>/<Repo>
+ARG <APP>_VERSION=1.2.3
+```
+
+- **`BUILD_FROM` must carry a default.** Supervisor stopped supplying it in
+  2026.04, so `FROM $BUILD_FROM` with no default expands to `FROM ` and fails.
+- **There is no `build.yaml`.** It is deprecated. The base image and the OCI
+  labels live in the Dockerfile.
+- **`BUILD_ARCH` and `BUILD_VERSION` are injected** by the build action, along
+  with the `io.hass.*` labels. Do not duplicate those labels.
+- The `# renovate:` annotation is load-bearing; see Releases.
+
+`ghcr.io/home-assistant/base` is Alpine and supplies s6-overlay, bashio, curl,
+and jq. `base-ubuntu` is the Debian-family equivalent. Both are multi-arch, so
+one tag covers every architecture.
+
+### 5. `rootfs/`
+
+Copy the upstream service definition. The layout Supervisor expects:
+
+```
+rootfs/etc/s6-overlay/s6-rc.d/<slug>/run          executable
+rootfs/etc/s6-overlay/s6-rc.d/<slug>/finish       executable
+rootfs/etc/s6-overlay/s6-rc.d/<slug>/type         contains "longrun"
+rootfs/etc/s6-overlay/s6-rc.d/<slug>/dependencies.d/base    empty
+rootfs/etc/s6-overlay/s6-rc.d/user/contents.d/<slug>        empty
+```
+
+`run` and `finish` need the executable bit. The empty marker files must exist
+and stay empty.
+
+### 6. Register it
+
+- Add a section to the repository `README.md`, in alphabetical order.
+- Add the package to `release-please-config.json` and
+  `.release-please-manifest.json`, both alphabetically.
+
+### 7. Verify before pushing
+
+Every one of these has caught a real failure. Run them.
+
+**Validate against the linter's own schema**, rather than waiting for CI to tell
+you:
+
+```shell
+gh api repos/frenck/action-addon-linter/contents/src/config.schema.json \
+  --jq '.content' | base64 -D > /tmp/addon.schema.json
+```
+
+Then check your `config.yaml`'s map types and top-level keys against it. This
+exists because the linter rejects values Supervisor documents as current.
+
+**Build and boot it.** A green build proves nothing about whether the thing
+starts:
+
+```shell
+docker build --platform linux/arm64 --build-arg BUILD_ARCH=aarch64 \
+  --build-arg BUILD_VERSION=1.0.0 -t <slug>-test .
+```
+
+Run it with `/config` and `/data` mounted, then check the logs for the version
+and a listening port, and probe the port for a response. Build for the
+architecture you are actually on — see Traps.
+
+**Run `npx prettier --check`** over the application directory. Prettier formats
+YAML, JSON and Markdown here, and CI checks it.
+
+## Conventions
+
+### Key ordering
+
+Keys in JSON and YAML configuration files are ordered by name. Files whose order
+carries meaning are exempt: workflows, where step order is execution order;
+changelogs, which are chronological; and `package.json`, where the npm ecosystem
+expects `name` and `version` first.
+
+### Workflow naming
+
+A workflow's filename is the kebab-case of its `name:` field. Reusable
+workflows, meaning those triggered only by `workflow_call`, take a leading
+underscore. Job names and step names are imperative verb phrases. Job ids, step
+ids, and matrix keys are exempt.
+
+### Image naming
+
+An application's `image` is the generic multi-architecture name with no
+placeholder. The per-architecture images published underneath it are named
+`{arch}-<image>`, architecture first — that order is fixed by the build action
+and is not ours to choose.
+
+### Commits
+
+Conventional Commits. The type decides whether users see the change:
+
+| Type          | Effect                                               |
+| ------------- | ---------------------------------------------------- |
+| `feat`        | releases the application, minor bump                 |
+| `fix`         | releases the application, patch bump                 |
+| anything else | no release, so nothing reaches an installed instance |
+
+## Releases
+
+Home Assistant decides an update exists by comparing `config.yaml`'s `version`
+against the installed one — a plain inequality, so the string only has to move.
+If it never moves, nothing you change inside an image ever reaches anyone.
+
+Nobody edits that field by hand. release-please owns it.
+
+```mermaid
+flowchart TD
+    A[Renovate finds a newer application version] --> B[PR bumping ARG in the Dockerfile]
+    B --> C{Merged to main?}
+    C -- no --> D([Nothing released])
+    C -- yes --> E[release-please opens a release PR]
+    E --> F[Bumps config.yaml version, writes the CHANGELOG]
+    F --> G{Release PR merged?}
+    G -- no --> D
+    G -- yes --> H[Build publishes the image at the new version]
+    H --> I([Home Assistant offers the update])
+```
+
+Each application is its own release-please package. A commit is attributed to
+one by the files it touches, so a change under `radarr/` releases Radarr alone.
+
+**Two annotations hold this together, and removing either fails silently.**
+
+- `# x-release-please-version` beside `version` in `config.yaml` tells
+  release-please which line to rewrite.
+- `# renovate: datasource=… depName=…` above the `ARG` in the Dockerfile tells
+  Renovate what to watch.
+
+Neither produces an error when missing. The application simply stops receiving
+updates, and nobody notices until someone checks.
+
+## Traps
+
+**The linter is behind Supervisor.** Supervisor deprecated `addon_config` for
+`app_config` in 2026.07, but `frenck/action-addon-linter` only accepts the old
+spelling and has had no release since 2025-11. Home Assistant's own apps-example
+runs the same linter. Use `addon_config` and leave the comment explaining why.
+Validate against the linter's schema locally rather than discovering this in CI.
+
+**Every arr project names its release assets differently.** These cannot be
+copied between applications:
+
+| Project  | Asset pattern                                             |
+| -------- | --------------------------------------------------------- |
+| Radarr   | `Radarr.master.<version>.linux-musl-core-<arch>.tar.gz`   |
+| Sonarr   | `Sonarr.main.<version>.linux-musl-<arch>.tar.gz`          |
+| Prowlarr | `Prowlarr.master.<version>.linux-musl-core-<arch>.tar.gz` |
+
+Check the published assets for the version you are pinning. A wrong URL fails
+only at build time.
+
+**amd64 images cannot be booted on an arm64 host.** The build succeeds, then x64
+.NET dies at startup with a `NullReferenceException` inside NLog. It is
+emulation, not your port. Build and boot `aarch64` natively, and let CI cover
+amd64 on a native runner.
+
+**A green build is not a working application.** Radarr, Sonarr and Prowlarr all
+built cleanly while failing to start. Boot the container and probe the port.
+
+**`UpdateMethod=docker` disables the application's own updater.** These images
+write it into `/opt/package_info` deliberately. The application will show that a
+newer version exists and refuse to install it, which is why the packaging is the
+only route to an update, and why the release chain above matters.
+
+**`apparmor.txt` is not free.** n8n carries the apps-example template verbatim,
+profile named `example` and referencing `/usr/bin/my_program`. Supervisor
+rewrites the profile name to the slug so it loads, but it describes nothing
+about n8n. Ship a real profile or ship none; do not copy that file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+Guidance for this repo is kept in `AGENTS.md` so it is shared with every coding
+agent rather than duplicated per tool. It is imported below, which is what puts
+it in Claude Code's context automatically.
+
+@AGENTS.md


### PR DESCRIPTION
## Summary

Writes down how an application is built here, so the fifth one does not rediscover the failures the first four already paid for.

Everything the four existing applications share is currently tacit. It lives in the directories themselves, which means it is only learned by getting it wrong.

Stacked on [#55](https://github.com/kanso-labs/home-assistant-applications/pull/55), because it documents the release chain that pull request introduces. It retargets to `main` on its own once that merges.

## Problem

Four applications exist and their shape is real and consistent, but nothing states it. An agent adding a fifth has the existing directories to copy from and no way to tell which parts are load-bearing.

That is not hypothetical. Every one of these happened while building the four:

- A `build.yaml` carried over from upstream that Home Assistant had deprecated.
- An `ARG BUILD_FROM` with no default. Supervisor stopped supplying it in 2026.04, so `FROM $BUILD_FROM` expanded to `FROM ` and the build died.
- A `config.yaml` using `app_config`, which Supervisor documents as current and the linter rejects outright.
- Three images that built perfectly green and then failed to start.

The last one is the reason a written verify step matters more than a written convention.

## Solution

`AGENTS.md` records the shape and the reasoning behind it. `CLAUDE.md` is a four-line shim that imports it, matching [kanso-ui](https://github.com/kanso-labs/kanso-ui), so one document reaches every tool instead of being duplicated per vendor.

It opens by ranking the sources, because they disagree and the order matters: Supervisor's own code first, then the reference implementation, then the documentation, and last the linter — which is not an authority but is the gate.

The bulk is seven steps for adding an application, covering the directory contents, `config.yaml`, the Dockerfile, the s6 layout, registration, and verification. Conventions and the release chain follow.

**Two sections carry most of the value.**

**Verify before pushing** gives the command to fetch the linter's own `config.schema.json` and validate against it locally. That is what turned Radarr's red CI into Sonarr's and Prowlarr's passing first time. It also says to build and boot natively for `aarch64` and probe the port, because a green build proved nothing three times running.

**Traps** is the part worth keeping, and every entry cost real time to find:

| Trap | Why it bites |
| --- | --- |
| The linter lags Supervisor | `app_config` is current and rejected; `addon_config` is deprecated and required |
| Each arr project names assets differently | The download URLs cannot be copied between applications |
| amd64 will not boot on an arm64 host | x64 .NET dies in NLog under emulation, which looks like a broken port |
| A green build is not a working application | Three of them built cleanly and failed to start |
| `UpdateMethod=docker` disables the app's own updater | Which is why the release chain is the only route to an update |
| `apparmor.txt` is not free | n8n's is the example template verbatim, describing nothing about n8n |

## Evidence

The document was checked against the repository rather than written from memory. The rootfs layout it describes matches `radarr/` exactly:

```
rootfs/etc/s6-overlay/s6-rc.d/radarr/dependencies.d/base     0 bytes
rootfs/etc/s6-overlay/s6-rc.d/radarr/finish                  executable
rootfs/etc/s6-overlay/s6-rc.d/radarr/run                     executable
rootfs/etc/s6-overlay/s6-rc.d/radarr/type                    longrun
rootfs/etc/s6-overlay/s6-rc.d/user/contents.d/radarr         0 bytes
```

The base images it names are the ones the Dockerfiles actually use, and every file it references exists.

## Rollback Plan

Revert via GitHub's Revert button. Nothing executes from either file, so a revert only removes guidance.

## Test plan

**Verifiable by agent before merging**

- [x] The documented rootfs layout, executable bits, and empty marker files match `radarr/` exactly
- [x] The base images named in the document are those the Dockerfiles actually use
- [x] Every file the document references exists in the repository
- [x] `prettier --check` passes on both new files

Nothing here changes behaviour, and its accuracy was checked above, so there is nothing that needs a live environment to confirm.
