### PR TITLE
chore: automerge minor dependency updates as well as patch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,7 @@
   "packageRules": [
     {
       "automerge": true,
-      "matchUpdateTypes": ["patch"]
+      "matchUpdateTypes": ["minor", "patch"]
     },
     {
       "groupName": "Home Assistant Base Images",


### PR DESCRIPTION
## Summary

Widens Renovate's automerge rule from patch to minor, and reports that the rule it widens has never actually fired.

Stacked on [#55](https://github.com/kanso-labs/home-assistant-applications/pull/55), which last touched `renovate.json`. It retargets to `main` once that merges.

## Problem

`renovate.json` has carried `automerge: true` for patch updates, and no dependency pull request has ever been merged automatically. Every one so far was merged by hand.

`allow_auto_merge` is `false` on this repository. Renovate's `platformAutomerge` defaults to true and relies on exactly that feature, so the rule has been declaring an intent the platform could not carry out.

Widening the rule to minor does not fix that. Without one of the changes below, this changes nothing observable.

## Solution

The rule now covers `minor` and `patch`. Major updates stay manual, since those are the ones that change behaviour.

Making it actually merge takes one of two things:

| Approach | Effect |
| --- | --- |
| Enable auto-merge on the repository | Renovate uses GitHub's native auto-merge, which shows in the pull request UI and respects branch protection. A repository settings change. |
| Set `platformAutomerge: false` | Renovate merges through the API itself once checks pass. No settings change, but the merge happens outside GitHub's own auto-merge machinery. |

Both wait for checks. Neither bypasses CI.

## What this means once it works

An application bump would merge on its own, release-please would open a release pull request, and a human would still merge that. The gate moves from watching dependency pull requests to approving what actually ships, which is the more useful place for it.

**Worth weighing before enabling either:** CI proves an image builds, not that it starts. Radarr, Sonarr and Prowlarr each built cleanly and then failed to boot during development — that was caught by booting them locally, which CI does not do. Automerging minor updates means those images reach `main` unbooted.

Adding a smoke test that boots the container and probes its port would close that gap and make automerge genuinely safe. That is not in this pull request.

## Rollback Plan

Revert via GitHub's Revert button, which restores patch-only automerge. If auto-merge was enabled on the repository to make this work, turn that off separately — reverting this file does not touch the setting.

## Test plan

**Verifiable by agent before merging**

- [x] `renovate.json` parses and `prettier --check` passes
- [x] The change is confined to the one rule, confirmed by diff
- [x] No dependency pull request in this repository has ever auto-merged, and `allow_auto_merge` is `false`

**Cannot be verified before merge**

- [ ] That a minor update actually merges on its own — needs Renovate to run after this merges, and needs one of the two approaches above to be in place first
