### PR TITLE
docs: describe releases as driven by the pull request title

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,13 +195,22 @@ and is not ours to choose.
 
 ### Commits
 
-Conventional Commits. The type decides whether users see the change:
+Pull requests are squash-merged, with the pull request title as the commit
+subject and an empty body. That title becomes the only commit on `main`, so it
+is the single input to everything below. Branch commit messages are discarded by
+the squash and never reach history.
 
-| Type          | Effect                                               |
-| ------------- | ---------------------------------------------------- |
-| `feat`        | releases the application, minor bump                 |
-| `fix`         | releases the application, patch bump                 |
-| anything else | no release, so nothing reaches an installed instance |
+The title is a Conventional Commit. Its type decides whether users see the
+change:
+
+| Type of the pull request title | Effect                                               |
+| ------------------------------ | ---------------------------------------------------- |
+| `feat`                         | releases the application, minor bump                 |
+| `fix`                          | releases the application, patch bump                 |
+| anything else                  | no release, so nothing reaches an installed instance |
+
+Write branch commits conventionally anyway. They are what a reviewer reads while
+the pull request is open, even though only the title survives the merge.
 
 ## Releases
 
@@ -238,6 +247,29 @@ Neither produces an error when missing. The application simply stops receiving
 updates, and nobody notices until someone checks.
 
 ## Traps
+
+**Merge commits are disabled, and re-enabling them duplicates every changelog
+entry.** A merge commit carries the pull request title in its body, where it
+parses as a Conventional Commit, and it brings the branch's own commit onto
+`main` alongside it. release-please counts both and writes two entries with
+different SHAs and identical text. That is not hypothetical: it produced 10
+duplicated pairs across four open release pull requests before merge commits
+were turned off. Squashing writes one commit, and rebasing adds no merge commit
+to double-count, so both remaining strategies are safe.
+
+**Nothing enforces any of this.** There is no commitlint in this repository — no
+configuration, no dependency, no hook — and `.github/workflows/lint.yaml` runs
+only `frenck/action-addon-linter` over each application directory. Nothing reads
+the pull request title. A malformed one reaches `main` unchallenged and either
+lands in a changelog exactly as written or silently skips a release that should
+have happened.
+
+**One pull request, one application.** Attribution is by the files a commit
+touches, and squashing makes a pull request exactly one commit. So a pull
+request touching two applications writes a line into both changelogs and
+releases both, at whatever bump its single title implies — there is no way to
+say `feat` for one and `fix` for the other. Keeping a pull request to one
+application is what keeps changelogs clean.
 
 **The linter is behind Supervisor.** Supervisor deprecated `addon_config` for
 `app_config` in 2026.07, but `frenck/action-addon-linter` only accepts the old

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,15 @@ Each application is its own release-please package, versioned independently. A
 commit is attributed to an application by the files it touches, so a change
 under `radarr/` releases Radarr and nothing else.
 
-Only `fix` and `feat` commits produce a release. A `chore` changes nothing a
-user can see, so it deliberately does not.
+Pull requests are squash-merged, with the pull request title as the commit
+subject and an empty body. Your branch commit messages are discarded by the
+squash, so the title is the only one that reaches `main`. Write it as a
+Conventional Commit.
+
+Only a `fix` or `feat` title produces a release. A `chore` changes nothing a
+user can see, so it deliberately does not. Nothing checks the title before it
+merges, so a malformed one fails silently — it either lands in the changelog as
+written or skips a release that should have happened.
 
 The chain runs like this:
 
@@ -100,7 +107,10 @@ those are exactly the changes that need to reach users.
 - Submit a pull request, referencing any issues it addresses.
 
 Please try to keep your pull request focused in scope and avoid including
-unrelated commits.
+unrelated commits. Keep it to a single application where you can: a pull request
+is one commit after the squash, so one touching two applications writes a line
+into both changelogs and releases both, at whatever bump its single title
+implies.
 
 After you have submitted your pull request, we'll try to get back to you as soon
 as possible. We may suggest some changes or improvements.


### PR DESCRIPTION
## Summary

Corrects `AGENTS.md` and `CONTRIBUTING.md`, both of which described releases as driven by commit messages, after merge commits were disabled repository-wide to stop release-please writing every changelog entry twice.

Before that settings change, a pull request's branch commits landed on `main` and fed the changelog. Pull requests are now squash-merged with the title as the subject and an empty body, so the title is the only commit that reaches `main`, and the sole input to versioning and the changelog. Branch commit messages are discarded.

Documentation only. No application directory is touched, and the `docs:` title releases nothing.

## Problem

The repository merged pull requests with `merge_commit_title: MERGE_MESSAGE` and `merge_commit_message: PR_TITLE`. That put the pull request title in the merge commit's *body*, where release-please parsed it as a Conventional Commit. A merge commit also carries the branch's own commit onto `main`, so release-please counted both and emitted two entries with different SHAs and identical text.

That produced 11 duplicated pairs across the four open release pull requests — radarr 2, sonarr 2, prowlarr 2, n8n 5. Classifying every entry by parent count confirmed the cause: every duplicate was a merge-commit and branch-commit pair, with no exceptions.

Merge commits have since been disabled at the repository level, which fixes the duplication. But it also moves where releases are decided, and both documents still attributed that to commits. Left as they were, they instruct the next contributor — human or agent — to care about a message that the squash now throws away, and say nothing about the title that actually ships.

## Evidence

The settings change is already live, and the first pull request merged under it behaved as intended. Commit `53991aa` on `main`:

```
53991aa parents=1  feat(bazarr): add Bazarr as an application (#62)
--- body ---
|Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
--- end body ---
```

One parent rather than two, the title as the subject with `(#62)` appended, and no branch commit beside it. Its release pull request ([#63](https://github.com/kanso-labs/home-assistant-applications/pull/63)) carries exactly one changelog entry, against two for every comparable pull request merged before the change.

## Solution

Both documents now describe the pull request title as the thing that drives a release, and record what fails silently around it.

**`AGENTS.md`, `### Commits`** — the Conventional Commit type table is now explicitly about the pull request title rather than the commit. The advice to write branch commits conventionally stays, with the reason attached: they are what a reviewer reads while the pull request is open, even though only the title survives the merge.

**`AGENTS.md`, `## Traps`** — three entries, in the section this repository already uses for things that fail without an error:

- Merge commits are disabled, and re-enabling them reintroduces the duplication. The entry gives the concrete figure so the next reader knows it happened rather than that it might, and notes that squashing and rebasing are both safe.
- Nothing enforces any of this. There is no commitlint in the repository, and `.github/workflows/lint.yaml` runs only `frenck/action-addon-linter` over each application directory, so nothing reads the title at all.
- One pull request, one application. Attribution is by the files a commit touches, and squashing makes a pull request exactly one commit, so one spanning two applications releases both at whatever bump its single title implies.

**`CONTRIBUTING.md`** — the same correction in `## Releases`, plus the single-application consequence in the pull request section, so a contributor reading only this file is not told something the agent-facing file contradicts.

`CLAUDE.md` is deliberately unchanged. It contains only `@AGENTS.md`, so the correction reaches it by import and nothing is duplicated.

## Design Decisions

| Decision | Context |
| --- | --- |
| No commitlint or pull request title linter | The title is now the sole input to versioning and nothing validates it, so a linter is worth adding. It is a CI behaviour change, and folding it into a documentation correction would put a new required check in a pull request nobody would look at for one. Better raised on its own. |
| The trap entries record the failure mode, not just the rule | This repository's `## Traps` section exists for things that produce no error. Writing "use squash" alone would leave the next person free to re-enable merge commits without knowing what it costs. |

## Test plan

**Verifiable by agent before merging**

- [x] `npx prettier --check AGENTS.md CONTRIBUTING.md` passes; both files were clean before this change and still are
- [x] `CLAUDE.md` is untouched — `git diff --name-only` lists only the two documents
- [x] The behaviour the documents now describe was confirmed against `main`, not assumed: `53991aa` has one parent, an empty body, and produced a single changelog entry

**Cannot be verified before merge**

- [ ] Confirm the described flow still holds for a Renovate automerge — the proving pull request ([#62](https://github.com/kanso-labs/home-assistant-applications/pull/62)) was human-authored, and no bot pull request has merged since the settings change

## Notes for the reviewer

`AGENTS.md` states that CI checks prettier formatting, and no workflow actually runs it. That claim was already wrong before this change and is left alone here rather than fixed in passing.
