### PR TITLE
ci: run release-please as an application and gate each workflow on one check

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,3 +79,32 @@ jobs:
       app: ${{ matrix.app }}
       publish: ${{ github.event_name == 'push' }}
     secrets: inherit
+
+  # One job with a fixed name for branch protection to require. The build runs
+  # only for the applications a pull request touches, so its own check names are
+  # absent on any pull request that changes none of them, and requiring those
+  # directly would block every such pull request forever.
+  confirm:
+    name: Confirm builds succeeded
+    runs-on: ubuntu-latest
+    needs: [init, build-application]
+    if: always()
+    steps:
+      - name: Check the build result
+        env:
+          DETECT: ${{ needs.init.result }}
+          BUILD: ${{ needs.build-application.result }}
+        run: |
+          if [[ "${DETECT}" != 'success' ]]; then
+            echo "Detecting the changed applications failed (${DETECT})."
+            exit 1
+          fi
+
+          case "${BUILD}" in
+            success) ;;
+            skipped) echo 'No application changed, so nothing was built.' ;;
+            *)
+              echo "At least one application failed to build (${BUILD})."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -39,3 +39,21 @@ jobs:
         uses: frenck/action-addon-linter@v2.21
         with:
           path: './${{ matrix.path }}'
+
+  # One job with a fixed name for branch protection to require. The linter runs
+  # once per application, so its own check names change whenever an application
+  # is added, and a forgotten name fails silently by never being required.
+  confirm:
+    name: Confirm lint succeeded
+    runs-on: ubuntu-latest
+    needs: lint
+    if: always()
+    steps:
+      - name: Check the lint result
+        env:
+          RESULT: ${{ needs.lint.result }}
+        run: |
+          if [[ "${RESULT}" != 'success' ]]; then
+            echo "At least one application failed linting (${RESULT})."
+            exit 1
+          fi

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   find:
     name: Find applications

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -12,11 +12,20 @@ jobs:
   release-please:
     name: Propose releases
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
+      # Pull requests opened with the default GITHUB_TOKEN do not start
+      # workflow runs. Their checks sit at action_required until somebody
+      # approves them by hand, so a release stalls until then. Requests made
+      # with an application token trigger the checks like any other.
+      - name: Mint an application token
+        id: token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
+
       - name: Propose releases
+        id: release
         uses: googleapis/release-please-action@v5.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
## Summary

Makes the checks on a release pull request actually run, by raising those pull requests with a GitHub App token instead of the workflow's default `GITHUB_TOKEN`.

Until now every check on a release pull request was created and then parked at `action_required`, waiting for somebody to press "Approve and run". A release only moved when a human noticed it sitting there. They now start on their own, like the checks on any other pull request.

Each workflow also gains one job with a fixed name, so there is something stable for branch protection to require later.

> [!IMPORTANT]
> Do not merge until `RELEASE_PLEASE_PRIVATE_KEY` exists on the repository. `RELEASE_PLEASE_APP_ID` is already set. Without the key, minting the token fails and release-please stops running at all, which is worse than the current state.

## Problem

`release-please.yaml` passed `secrets.GITHUB_TOKEN` to release-please. GitHub deliberately does not start workflow runs for pull requests opened with that token, to stop workflows triggering themselves in a loop.

The effect was not that checks failed. They were created and then held, so a release pull request sat with nothing having run against it until a human approved the runs by hand or pushed to the branch themselves. Every release in this repository has been moving at the speed of someone remembering to look.

This also blocks anything automatic downstream. Auto-merging a release when its checks pass is impossible while the checks never start.

## Evidence

Querying the Actions API for runs on the `release-please--branches--main--components--*` branches, every run triggered by the bot ended the same way:

```
n8n      | Build | ev=pull_request | actor=github-actions[bot] | action_required
n8n      | Lint  | ev=pull_request | actor=github-actions[bot] | action_required
bazarr   | Build | ev=pull_request | actor=github-actions[bot] | action_required
radarr   | Build | ev=pull_request | actor=github-actions[bot] | action_required
```

Every run on those same branches that reached `success` had `triggering_actor=rodrigoscna` — it ran because a person pushed to the branch or approved it, never because the pull request was opened.

## Solution

**Releases are raised as a GitHub App.** `release-please.yaml` mints a short-lived token with `actions/create-github-app-token@v2` and hands that to release-please instead of `GITHUB_TOKEN`. Requests made with an App token start checks like any other actor.

The file carries a comment explaining why. Changing it back to `GITHUB_TOKEN` would not error — it would quietly return to parking every check, which is the kind of silent regression this repository already documents in its Traps.

The job's `permissions: contents: write` and `pull-requests: write` block is removed, because the App token now performs every write and the default token no longer needs the elevation.

**One check per workflow worth requiring.** `Confirm lint succeeded` and `Confirm builds succeeded` each run with `if: always()` and inspect the result of the jobs they depend on. Neither adds coverage; they exist so a ruleset has a name that is always reported.

The existing check names cannot serve that purpose:

| Check | Why it cannot be required |
| --- | --- |
| `Lint <app>` | One per application, so the set of names changes whenever an application is added. Forgetting to add the new name is silent — it simply never becomes required. |
| `Build <app>` | Gated on `needs.init.outputs.changed`, so it is absent entirely on a pull request that touches no application. Requiring it would block every such pull request forever. |

This pull request is itself the second case: it changes no application directory, so no `Build <app>` check appears on it.

`Confirm builds succeeded` treats a `skipped` build as a pass, which is that same "nothing to build" case and covers most release pull requests. A matrix job's result is already the aggregate of its legs, so one failed application fails the gate.

**The Lint workflow's token is limited to reading contents.** It declared no permissions at all, so its jobs ran with the repository default of `write` — a write-scoped token for a workflow whose only job is running a third-party linter over each application.

Code scanning raised this against the new job, but the gap was already there. The two pre-existing jobs inherited the same default and were never flagged, because neither appeared in a diff.

Setting it once at the workflow level closes it for all three jobs, and matches `build.yaml` and `release-please.yaml`, which both already declared `contents: read`. Nothing in the workflow needs more.

**Auto-merge is deliberately not enabled here.** It needs the two steps after this one, in order:

1. Create a ruleset requiring the two check names, and turn on `allow_auto_merge`.
2. Add the step that calls `gh pr merge --auto` on the pull requests release-please raises.

Doing either earlier breaks. `gh pr merge --auto` on a pull request with nothing blocking it merges immediately, so wiring it up before the ruleset exists would land release pull requests with no checks run at all. And a ruleset naming these checks cannot be created before the jobs exist and have reported once, or every open pull request blocks on a check that never arrives — including this one.

## Review Guide

```
release-please.yaml   ← mints the App token, raises the release pull requests
lint.yaml
   ├── lint           (matrix, one leg per application)
   └── confirm        ← "Confirm lint succeeded", the requirable name
build.yaml
   ├── init           ← decides which applications changed
   ├── build-application  →  _build-application.yaml   (matrix, only changed applications)
   └── confirm        ← "Confirm builds succeeded", the requirable name
```

Focus areas:

- **`.github/workflows/build.yaml`, the `confirm` job** — the `skipped` case has to pass or every release pull request blocks, and the `if: always()` has to stay or the job is skipped along with its dependencies and never reports at all.
- **`.github/workflows/release-please.yaml`** — the removed `permissions` block is the most likely thing to need putting back if a step returns 403 after merge.

## Design Decisions

| Decision | Context |
| --- | --- |
| Add gate jobs rather than require the existing checks | Requiring `Lint <app>` names directly would work today and rot silently: adding an application adds a check nobody remembers to require. The gate job's name never changes. |
| Split auto-merge into a follow-up | Enabling it here would merge release pull requests the moment they open, because auto-merge on an unblocked pull request merges at once. The ruleset has to exist first, and it cannot be created until these jobs have reported. |
| A GitHub App rather than a personal access token | Both fix the trigger problem. An App is owned by the organisation, so it outlives any one person's account and its key can be rotated by any admin. |

## Blast Radius

Not gated by anything — it applies to the next push to `main`.

The risk worth watching is release-please itself. If the private key is missing or wrong, the token step fails and the workflow stops before proposing anything, so releases go quiet rather than loud. After merging, confirm the Release Please workflow succeeded on `main` and that the next release pull request shows checks running with the App as the actor.

## Rollback Plan

Revert this pull request. Releases go back to being proposed with `GITHUB_TOKEN`, and their checks go back to waiting for manual approval.

## Test plan

**Verifiable by agent before merging**

- [x] `actionlint` over all workflows reports nothing in the added jobs. Its one finding, `SC2206` at `build.yaml:41`, is pre-existing — confirmed by running `actionlint` against `origin/main`'s copy of the file and getting the identical warning.
- [x] `npx prettier --check` clean on all three workflows.
- [x] Job graph resolves as intended: `build` is `init, build-application, confirm`; `lint` is `find, lint, confirm`.
- [x] All three workflows now declare `permissions: contents: read`, and every job in them either checks out the repository or touches nothing at all.
- [x] `RELEASE_PLEASE_APP_ID` is set on the repository.

**Cannot be verified before merge**

- [ ] That an App token starts checks unattended — the behaviour only appears on a pull request release-please opens itself, which cannot happen until this is on `main`. Afterwards, runs on the release branches should read `conclusion=success` with the App as `triggering_actor`, rather than `action_required`.
- [ ] `RELEASE_PLEASE_PRIVATE_KEY` set on the repository — it holds a private key, so it has to be added by hand.

The hub-and-spoke canary procedure does not apply here. These workflows are standalone and no other repository consumes them.

