### PR TITLE
chore: stop release-please rewriting config.yaml on every release

### DIFF
--- a/nzbget/config.yaml
+++ b/nzbget/config.yaml
@@ -2,12 +2,16 @@ arch:
   - aarch64
   - amd64
 backup: cold
-description: >-
+description:
   Usenet downloader with a web interface. NZBGet fetches from your news servers
   into shared storage, where the rest of the stack can pick it up.
-image: ghcr.io/kanso-labs/home-assistant-application-nzbget
+image: 'ghcr.io/kanso-labs/home-assistant-application-nzbget'
 init: false
 map:
+  # Supervisor deprecated `addon_config` for `app_config` in 2026.07, but
+  # frenck/action-addon-linter still only accepts the older spelling and has
+  # had no release since 2025-11. Home Assistant's own apps-example runs the
+  # same linter. Switch this once the linter's schema catches up.
   - read_only: false
     type: addon_config
   - read_only: false
@@ -18,6 +22,6 @@ ports:
 ports_description:
   6789/tcp: Web interface
 slug: nzbget
-url: https://github.com/kanso-labs/home-assistant-applications/tree/main/nzbget
-version: 1.1.0
-webui: http://[HOST]:[PORT:6789]
+url: 'https://github.com/kanso-labs/home-assistant-applications/tree/main/nzbget'
+version: '1.1.0' # x-release-please-version
+webui: 'http://[HOST]:[PORT:6789]'

--- a/qbittorrent/config.yaml
+++ b/qbittorrent/config.yaml
@@ -2,12 +2,16 @@ arch:
   - aarch64
   - amd64
 backup: cold
-description: >-
+description:
   BitTorrent client with a web interface. qBittorrent downloads torrents into
   shared storage, where the rest of the stack can pick them up.
-image: ghcr.io/kanso-labs/home-assistant-application-qbittorrent
+image: 'ghcr.io/kanso-labs/home-assistant-application-qbittorrent'
 init: false
 map:
+  # Supervisor deprecated `addon_config` for `app_config` in 2026.07, but
+  # frenck/action-addon-linter still only accepts the older spelling and has
+  # had no release since 2025-11. Home Assistant's own apps-example runs the
+  # same linter. Switch this once the linter's schema catches up.
   - read_only: false
     type: addon_config
   - read_only: false
@@ -22,7 +26,6 @@ ports_description:
   6881/udp: Peer connections and DHT
   8080/tcp: Web interface
 slug: qbittorrent
-url: >-
-  https://github.com/kanso-labs/home-assistant-applications/tree/main/qbittorrent
-version: 1.1.0
-webui: http://[HOST]:[PORT:8080]
+url: 'https://github.com/kanso-labs/home-assistant-applications/tree/main/qbittorrent'
+version: '1.1.0' # x-release-please-version
+webui: 'http://[HOST]:[PORT:8080]'

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,35 +3,35 @@
   "packages": {
     "bazarr": {
       "component": "bazarr",
-      "extra-files": ["config.yaml"]
+      "extra-files": [{ "path": "config.yaml", "type": "generic" }]
     },
     "n8n": {
       "component": "n8n",
-      "extra-files": ["config.yaml"]
+      "extra-files": [{ "path": "config.yaml", "type": "generic" }]
     },
     "notifiarr": {
       "component": "notifiarr",
-      "extra-files": ["config.yaml"]
+      "extra-files": [{ "path": "config.yaml", "type": "generic" }]
     },
     "nzbget": {
       "component": "nzbget",
-      "extra-files": ["config.yaml"]
+      "extra-files": [{ "path": "config.yaml", "type": "generic" }]
     },
     "prowlarr": {
       "component": "prowlarr",
-      "extra-files": ["config.yaml"]
+      "extra-files": [{ "path": "config.yaml", "type": "generic" }]
     },
     "qbittorrent": {
       "component": "qbittorrent",
-      "extra-files": ["config.yaml"]
+      "extra-files": [{ "path": "config.yaml", "type": "generic" }]
     },
     "radarr": {
       "component": "radarr",
-      "extra-files": ["config.yaml"]
+      "extra-files": [{ "path": "config.yaml", "type": "generic" }]
     },
     "sonarr": {
       "component": "sonarr",
-      "extra-files": ["config.yaml"]
+      "extra-files": [{ "path": "config.yaml", "type": "generic" }]
     }
   },
   "release-type": "simple",


### PR DESCRIPTION
## Summary

Fixes release-please stripping every comment out of an application's `config.yaml` each time it releases, caused by a plain string entry in `extra-files` selecting a js-yaml round-trip updater rather than the annotation-based one, by switching those entries to the object form that edits only the annotated line.

Before this change, a release rewrote the whole file: quotes dropped, long scalars folded to `>-`, and every comment removed. Releases now touch the single `version` line and leave the rest of the file byte-identical.

The two applications whose damage reached `main` are restored here as well.

## Problem

Every release so far has re-serialised the config of the application it released. Three kinds of comment are lost, and the first two carry weight:

- **`# x-release-please-version`** marks the line release-please rewrites. [AGENTS.md](AGENTS.md) calls this annotation load-bearing, and notes that removing it fails silently.
- **The `map` note** records that `addon_config` is deliberate — Supervisor deprecated it for `app_config` in 2026.07, but `frenck/action-addon-linter` still rejects the new spelling and has had no release since 2025-11. Without that note, the next person to read the file sees a deprecated value and corrects it into one CI refuses.
- **Per-application comments** go too, so the loss is not limited to the boilerplate every config shares.

Repairing this by hand on each release pull request is what has been happening, and it only works when someone notices in time.

## Evidence

[PR #76](https://github.com/kanso-labs/home-assistant-applications/pull/76) is doing it right now, unrepaired, to Notifiarr:

```diff
-description:
+description: >-
   Unified client for Notifiarr.com. Notifiarr reports on the applications you
-image: 'ghcr.io/kanso-labs/home-assistant-application-notifiarr'
+image: ghcr.io/kanso-labs/home-assistant-application-notifiarr
 map:
-  # Supervisor deprecated `addon_config` for `app_config` in 2026.07, but
-  # frenck/action-addon-linter still only accepts the older spelling and has
-  # had no release since 2025-11. Home Assistant's own apps-example runs the
-  # same linter. Switch this once the linter's schema catches up.
   - read_only: false
     type: addon_config
-  # Notifiarr reports free space on the storage it can see, and never writes.
   - read_only: true
     type: share
```

The last hunk is the one to note. That comment exists only in Notifiarr's config, so this is not a template problem — any comment an application carries is removed.

The same thing happened on every earlier release. Radarr's merged release commit `7fd24f5` looks like a clean one-line bump, but that is the end state: the bot's own commit `b365ed7e` was a 19-line re-serialisation, and a follow-up commit named `chore: correct the radarr release pull request` put it back. The n8n and Bazarr release pull requests carry the same two-commit shape. qBittorrent's `#69` has only the bot commit, which is why its damage reached `main`.

release-please states the behaviour in `src/updaters/generic-yaml.ts`:

> the used parser does reformat the document and removes all comments… If you want to retain formatting, use generic updater with comment hints.

Tooling drift is ruled out. The action has been pinned to `googleapis/release-please-action@v5.0.0` since it was introduced and never changed, no `release-please` version was published on release day (latest is 17.11.1 from 2026-07-31), and `release-please-config.json` had the same shape at the clean release and the damaged one.

## Solution

A string entry in `extra-files` ending in `.yaml` does not select the comment-preserving updater. `src/strategies/base.ts` pairs two updaters and runs them in order, and the first one destroys what the second looks for.

```mermaid
flowchart TD
    A["extra-files entry"] --> B{"string or object?"}
    B -- 'config.yaml' --> C["CompositeUpdater"]
    C --> D["GenericYaml: js-yaml parse + dump"]
    D --> E["Generic: annotation gone, nothing to edit"]
    E --> F(["Whole file re-serialised"])
    B -- "{path, type: generic}" --> G["Generic only"]
    G --> H(["One line edited, comments intact"])
```

`CompositeUpdater` chains unconditionally, so there is no input for which the string form preserves comments. The object form selects `case 'generic'` in the same switch, which is the "generic updater with comment hints" the note above points at.

Running the real release-please updaters against both configs as release-please saw them:

| | current `["config.yaml"]` | this PR `{path, type: "generic"}` |
|---|---|---|
| `x-release-please-version` kept | no | **yes** |
| `addon_config` note kept | no | **yes** |
| lines changed, radarr | 19 | **1** |
| lines changed, qbittorrent | 24 | **1** |
| resulting version line | `version: 1.1.0` | `version: '1.1.0' # x-release-please-version` |

All eight packages are converted, Notifiarr included. It arrived with the string form in [#74](https://github.com/kanso-labs/home-assistant-applications/pull/74) and is still unreleased at `1.0.0`, so converting it now protects it before its first release rather than after.

`qbittorrent/config.yaml` and `nzbget/config.yaml` are restored to their pre-release formatting with the released version carried forward at `1.1.0`, so no installed version moves.

## Review Guide

No call-flow tree applies — the change is three configuration files with no code path between them.

- **`release-please-config.json`** — the behavioural change. Worth confirming `type` is set on every package, since a missed one keeps the old behaviour silently. Notifiarr is the live example of how one gets missed: it was added by a pull request that had no reason to know about this one.
- **`qbittorrent/config.yaml:30`, `nzbget/config.yaml:26`** — the restored version lines must keep both the quotes and the trailing annotation. Without the annotation, the new updater has nothing to match.

## Design Decisions

| Decision | Context |
|---|---|
| Accept losing the jsonpath fallback | The string form also bumps `$.version` by jsonpath, which works whether or not the annotation is present. The object form matches only the annotation, so an application that loses it stops being bumped silently. Keeping the fallback would mean keeping the re-serialisation that removes the annotation in the first place, so the fallback protects against a failure the fallback causes. A CI guard asserting the annotation exists is the better backstop, and is not in this pull request. |
| Use `type: "generic"`, absent from the published schema | The schema's enum is only `json`/`toml`/`yaml`/`xml`, so an editor may flag this. It is nonetheless a real branch in the strategy switch and the one the documentation refers to. The alternative, annotating each release pull request by hand, is what has been happening and is what this fixes. |
| Title as `chore`, not `fix` | A `fix` would release the touched applications and write an entry into each changelog. There is no user-facing change here — the images at `1.1.0` are unaffected. `chore` releases nothing, which is also why this can touch two applications without tripping the repository's one-application-per-pull-request rule. |

## Dependencies

Merge this before [#76](https://github.com/kanso-labs/home-assistant-applications/pull/76). Nothing breaks if the order slips, but the work changes:

- **This first** — release-please regenerates #76 on its next run, and Notifiarr's config comes through intact.
- **#76 first** — `notifiarr/config.yaml` lands re-serialised on `main` and needs another hand repair, on top of this pull request.

## Rollback Plan

Revert via GitHub's Revert button. Nothing is published and no version moves, so the only consequence is that releases resume re-serialising the file, and release pull requests need the manual correction commit again.

## Test plan

**Verifiable by agent before merging**
- [x] Ran the real release-please updaters (`GenericYaml`, `Generic`, `CompositeUpdater` from the published package) against the pre-release Radarr and qBittorrent configs, comparing both forms — results in the table above
- [x] Confirmed `case 'generic'` exists in `src/strategies/base.ts` and constructs `Generic` with no YAML round-trip
- [x] Confirmed all eight packages in `release-please-config.json` carry `type: "generic"`
- [x] Both restored configs validated against `frenck/action-addon-linter`'s own `config.schema.json` — no unknown top-level keys, `map` types unchanged
- [x] Lint passed for every application on CI, which is the check that matters most here: it confirms the restored `addon_config` value and re-quoted scalars are what the linter accepts
- [x] nzbget and qbittorrent images built on both aarch64 and amd64; manifest publish skipped, as publish only runs on `main`
- [x] `x-release-please-version` present in the nzbget, qbittorrent, radarr and notifiarr configs
- [x] Ruled out tooling drift as an explanation — action pin unchanged, no package release on the day, identical config shape at both releases

**Cannot be verified before merge**
- [ ] The next real release produces a one-line diff to `config.yaml` with comments intact — requires release-please to run against `main`, which only happens after a releasing commit merges
- [ ] Home Assistant offers the update for an application released after this lands — requires an installed Supervisor instance
