### PR TITLE
chore: harden builds against GitHub release download failures

### DIFF
--- a/.github/workflows/_build-application.yaml
+++ b/.github/workflows/_build-application.yaml
@@ -81,6 +81,7 @@ jobs:
           arch: ${{ matrix.arch }}
           container-registry-password: ${{ secrets.GITHUB_TOKEN }}
           context: './${{ inputs.app }}'
+          cosign: ${{ inputs.publish }}
           image: ${{ matrix.image }}
           image-tags: |
             ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,6 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         app: ${{ fromJSON(needs.init.outputs.changed_apps) }}
+      max-parallel: 2
     uses: ./.github/workflows/_build-application.yaml
     with:
       app: ${{ matrix.app }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,6 +302,26 @@ copied between applications:
 Check the published assets for the version you are pinning. A wrong URL fails
 only at build time.
 
+**Every `curl` of a GitHub release asset needs retries and `-f`.** Release
+downloads return 503, or die mid-transfer, often enough to redden several builds
+an hour during a bad spell, and each architecture of each application is another
+draw. Plain `curl -L -o` handles neither: without `--retry` the first failure is
+fatal, and without `-f` a 503 body is written to the file and curl exits 0, so
+the build fails later in `tar` or `gunzip` with something that reads like a
+corrupt release. Use
+`curl -J -L -f --retry 8 --retry-all-errors --retry-max-time 180 -o`.
+
+`--retry-all-errors` is the load-bearing flag — bare `--retry` covers 5xx but
+not the connection dying mid-transfer, which is half of what is seen. The window
+has to be minutes rather than seconds: a fixed five-second delay across five
+retries covers under thirty seconds, and a spell outlasted that in three jobs of
+one run. Leave `--retry-delay` off so the backoff stays exponential, and bound
+it with `--retry-max-time` instead.
+
+The same spell leaves most jobs of the same run untouched, so it is throttling
+rather than an outage, and firing every application at once is what draws it.
+That is why `build.yaml` caps `max-parallel`.
+
 **amd64 images cannot be booted on an arm64 host.** The build succeeds, then x64
 .NET dies at startup with a `NullReferenceException` inside NLog. It is
 emulation, not your port. Build and boot `aarch64` natively, and let CI cover

--- a/bazarr/Dockerfile
+++ b/bazarr/Dockerfile
@@ -26,7 +26,7 @@ RUN \
     mediainfo \
     unzip \
   \
-  && curl -J -L -o /tmp/unrar.tar.gz \
+  && curl -J -L -f --retry 8 --retry-all-errors --retry-max-time 180 -o /tmp/unrar.tar.gz \
       "https://www.rarlab.com/rar/unrarsrc-${UNRAR_VERSION}.tar.gz" \
   && tar zxf \
       /tmp/unrar.tar.gz \
@@ -34,7 +34,7 @@ RUN \
   && make -C /tmp/unrar \
   && install -v -m755 /tmp/unrar/unrar /usr/local/bin \
   \
-  && curl -J -L -o /tmp/bazarr.zip \
+  && curl -J -L -f --retry 8 --retry-all-errors --retry-max-time 180 -o /tmp/bazarr.zip \
       "https://github.com/morpheus65535/bazarr/releases/download/v${BAZARR_VERSION}/bazarr.zip" \
   && unzip -q \
       /tmp/bazarr.zip \

--- a/n8n/Dockerfile
+++ b/n8n/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # Install mise
-RUN curl https://mise.run | sh
+RUN curl -L -f --retry 8 --retry-all-errors --retry-max-time 180 https://mise.run | sh
 ENV PATH="/root/.local/bin:$PATH"
 
 # Copy root filesystem

--- a/notifiarr/Dockerfile
+++ b/notifiarr/Dockerfile
@@ -18,7 +18,7 @@ RUN \
   elif [ "${BUILD_ARCH}" = "amd64" ]; then NOTIFIARR_ARCH="amd64"; \
   else echo "Unsupported architecture: ${BUILD_ARCH}" && exit 1; fi \
   \
-  && curl -J -L -o /tmp/notifiarr.gz \
+  && curl -J -L -f --retry 8 --retry-all-errors --retry-max-time 180 -o /tmp/notifiarr.gz \
       "https://github.com/Notifiarr/notifiarr/releases/download/v${NOTIFIARR_VERSION}/notifiarr.${NOTIFIARR_ARCH}.linux.gz" \
   && mkdir -p /opt/notifiarr \
   && gunzip -c /tmp/notifiarr.gz > /opt/notifiarr/notifiarr \

--- a/nzbget/Dockerfile
+++ b/nzbget/Dockerfile
@@ -21,7 +21,7 @@ RUN \
   elif [ "${BUILD_ARCH}" = "amd64" ]; then NZBGET_ARCH="x86_64"; \
   else echo "Unsupported architecture: ${BUILD_ARCH}" && exit 1; fi \
   \
-  && curl -J -L -o /tmp/nzbget.run \
+  && curl -J -L -f --retry 8 --retry-all-errors --retry-max-time 180 -o /tmp/nzbget.run \
       "https://github.com/nzbgetcom/nzbget/releases/download/v${NZBGET_VERSION}/nzbget-${NZBGET_VERSION}-bin-linux.run" \
   \
   `# The installer ships every architecture. Naming one keeps only its binary,` \

--- a/prowlarr/Dockerfile
+++ b/prowlarr/Dockerfile
@@ -23,7 +23,7 @@ RUN \
   elif [ "${BUILD_ARCH}" = "amd64" ]; then PROWLARR_ARCH="x64"; \
   else echo "Unsupported architecture: ${BUILD_ARCH}" && exit 1; fi \
   \
-  && curl -J -L -o /tmp/prowlarr.tar.gz \
+  && curl -J -L -f --retry 8 --retry-all-errors --retry-max-time 180 -o /tmp/prowlarr.tar.gz \
       "https://github.com/Prowlarr/Prowlarr/releases/download/v${PROWLARR_VERSION}/Prowlarr.master.${PROWLARR_VERSION}.linux-musl-core-${PROWLARR_ARCH}.tar.gz" \
   && mkdir -p /opt/bin \
   && tar zxf \

--- a/radarr/Dockerfile
+++ b/radarr/Dockerfile
@@ -23,7 +23,7 @@ RUN \
   elif [ "${BUILD_ARCH}" = "amd64" ]; then RADARR_ARCH="x64"; \
   else echo "Unsupported architecture: ${BUILD_ARCH}" && exit 1; fi \
   \
-  && curl -J -L -o /tmp/radarr.tar.gz \
+  && curl -J -L -f --retry 8 --retry-all-errors --retry-max-time 180 -o /tmp/radarr.tar.gz \
       "https://github.com/Radarr/Radarr/releases/download/v${RADARR_VERSION}/Radarr.master.${RADARR_VERSION}.linux-musl-core-${RADARR_ARCH}.tar.gz" \
   && mkdir -p /opt/bin \
   && tar zxf \

--- a/sonarr/Dockerfile
+++ b/sonarr/Dockerfile
@@ -23,7 +23,7 @@ RUN \
   elif [ "${BUILD_ARCH}" = "amd64" ]; then SONARR_ARCH="x64"; \
   else echo "Unsupported architecture: ${BUILD_ARCH}" && exit 1; fi \
   \
-  && curl -J -L -o /tmp/sonarr.tar.gz \
+  && curl -J -L -f --retry 8 --retry-all-errors --retry-max-time 180 -o /tmp/sonarr.tar.gz \
       "https://github.com/Sonarr/Sonarr/releases/download/v${SONARR_VERSION}/Sonarr.main.${SONARR_VERSION}.linux-musl-${SONARR_ARCH}.tar.gz" \
   && mkdir -p /opt/bin \
   && tar zxf \


### PR DESCRIPTION

## Summary

Fixes builds going red several times an hour, caused by GitHub's release CDN throttling downloads from the runners, by removing the cosign download from pull request builds, widening the retry window on every remaining download from seconds to minutes, and running a full rebuild in waves rather than all at once ([run 31624779185](https://github.com/kanso-labs/home-assistant-applications/actions/runs/31624779185) is the reported case).

Before this change a single bad response from `github.com/.../releases/download` failed the job outright, whether it hit the cosign installer that `home-assistant/builder` pulls in or an application's own asset download.

Image signing on `main` is unchanged, so every published image is still signed.

## Problem

Four of the last five red Build runs failed on a GitHub release download rather than on anything in the changed code. Three failed inside the cosign installer, one inside an application's own Dockerfile.

| Run | Failed in | Error |
| --- | --- | --- |
| [31624779185](https://github.com/kanso-labs/home-assistant-applications/actions/runs/31624779185) (notifiarr aarch64) | cosign installer | `curl: (22) ... error: 503`, four times |
| [31624911806](https://github.com/kanso-labs/home-assistant-applications/actions/runs/31624911806) (nzbget amd64) | cosign installer | `curl: (22) ... error: 503`, four times |
| [31623213104](https://github.com/kanso-labs/home-assistant-applications/actions/runs/31623213104) (sonarr aarch64) | cosign installer | `curl: (56) Connection died` |
| [31624397501](https://github.com/kanso-labs/home-assistant-applications/actions/runs/31624397501) (notifiarr amd64) | notifiarr's own download | `curl: (56) Connection died` |

Two details explain why a transient failure was fatal rather than merely slow.

The cosign installer retried, but not for long. [`sigstore/cosign-installer`](https://github.com/sigstore/cosign-installer), pinned by [`home-assistant/builder`](https://github.com/home-assistant/builder), downloads with `curl --retry 3` — four attempts inside roughly seven seconds, a window that closed well before the bad spell did.

The two `(56)` failures were never retried at all. A bare `--retry` covers 5xx responses but not a connection dying mid-transfer, and the applications' own downloads used `curl -J -L -o` with no retry flag of any kind.

## Evidence

From [run 31624779185](https://github.com/kanso-labs/home-assistant-applications/actions/runs/31624779185/job/94208347644), the reported job. Every attempt lands inside a seven-second window:

```
INFO: Downloading bootstrap version 'v3.0.6' of cosign to verify version to be installed...
      https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-linux-arm64
17:52:45  curl: (22) The requested URL returned error: 503
17:52:46  curl: (22) The requested URL returned error: 503
17:52:48  curl: (22) The requested URL returned error: 503
17:52:52  curl: (22) The requested URL returned error: 503
##[error]Process completed with exit code 22.
```

**The first version of this pull request retried correctly and still lost**, which is what set the current retry window. Its [own build run](https://github.com/kanso-labs/home-assistant-applications/actions/runs/31634365526) carried `--retry 5 --retry-delay 5`, and the sonarr job shows all six attempts arriving exactly five seconds apart and every one of them refused:

```
#8  1.156 curl: (22) The requested URL returned error: 503
#8  6.199 curl: (22) The requested URL returned error: 503
#8 11.24  curl: (22) The requested URL returned error: 503
#8 16.29  curl: (22) The requested URL returned error: 503
#8 21.33  curl: (22) The requested URL returned error: 503
#8 26.89  curl: (22) The requested URL returned error: 503
```

The bazarr job in that same run held out for 56 seconds and never got through either. Meanwhile 11 of the 14 jobs succeeded against the same CDN at the same moment, and the same assets served fine from a laptop while those jobs were failing:

```
$ curl -o /dev/null -w "http=%{http_code} time=%{time_total}\n" -L -r 0-1000 \
    https://github.com/Sonarr/Sonarr/releases/download/v4.0.19.2979/Sonarr.main.4.0.19.2979.linux-musl-arm64.tar.gz
http=206 time=0.685828
```

An outage would have taken all 14 jobs down and would have answered a laptop the same way. Selective refusal under 14 simultaneous downloads is throttling, which is what the concurrency cap below addresses.

## Solution

Three changes: one removes a download, one survives a refused download, one stops provoking the refusals.

**Pull request builds no longer install cosign** (`.github/workflows/_build-application.yaml`). A pull request builds with `push: false`, so it signs nothing; cosign's only job there is verifying the `latest` cache image before the builder trusts it as a cache source. Publishing builds on `main` are untouched and still sign every image.

```mermaid
flowchart TD
    A[Build application] --> B{publish?}
    B -- "pull request, publish: false" --> C[cosign: false] --> D[Registry cache used unverified] --> E([Image built, discarded])
    B -- "push to main, publish: true" --> F[cosign: true] --> G[Install cosign from GitHub release] --> H[Verify cache, build, sign] --> I([Signed image pushed to ghcr.io])
```

The cost is that a pull request build now pulls the `latest` cache image without checking its signature. That image comes from this repository's own registry, and the build it feeds is discarded.

**Every download retries for minutes rather than seconds** (all seven application Dockerfiles). They now use `curl -J -L -f --retry 8 --retry-all-errors --retry-max-time 180 -o`.

- `--retry-all-errors` is the load-bearing flag. It is what covers a connection dying mid-transfer, which was half of the observed failures.
- No `--retry-delay`, so the backoff stays exponential and a brief blip still clears in a second or two. `--retry-max-time 180` bounds the tail instead.
- `-f` matters independently of retries. Without it curl writes a 503 error page to the output file and exits 0, so the build fails later in `tar` or `gunzip` looking like a corrupt release rather than a failed download.

**A full rebuild runs in waves** (`.github/workflows/build.yaml`). The application matrix now caps `max-parallel` at 2, so at most four image builds pull release assets at once instead of fourteen. An ordinary pull request touches a single application and never reaches the cap, so this costs wall-clock time only on a full rebuild — which is what a change to a workflow file, or to this pull request, triggers. That cost measured about a minute: a full rebuild took 7m36s at three lanes and 8m45s at two.

**`AGENTS.md` records the trap**, next to the existing warning about per-project asset naming, so the next application added starts with the right flags rather than rediscovering this.

## Review Guide

```
Build                      (.github/workflows/build.yaml)        ← changed: max-parallel on the application matrix
   │
   └── Build application    (.github/workflows/_build-application.yaml)   ← changed: passes cosign: <publish>
          │
          └── home-assistant/builder/actions/build-image          ← upstream; skips its cosign install when cosign is false
                 │
                 └── <slug>/Dockerfile                            ← changed: retry flags on every curl
```

**Focus areas**

- **[`.github/workflows/_build-application.yaml:84`](.github/workflows/_build-application.yaml)** — the one change with a security dimension. Worth confirming that `inputs.publish` is the right gate, and that turning cosign off does not disable signing anywhere it currently happens.
- **[`n8n/Dockerfile:19`](n8n/Dockerfile)** — the odd one out. It pipes to `sh` rather than writing to a file, so `-f` makes curl fail while `sh` still exits 0. A failed download surfaces one step later when `mise install` cannot find mise, rather than at the download itself.

## Design Decisions

| Decision | Context |
| --- | --- |
| Turn cosign off for pull requests rather than making its install more reliable | The install happens inside the upstream `build-image` composite action, which offers no retry knob and no way to reuse an already-installed binary. Pre-installing cosign does not help, because the installer downloads unconditionally. Removing the dependency where it earns nothing was the only lever available on our side. |
| Cap concurrency rather than authenticating the downloads | Authenticated release downloads get higher limits, but reaching them means resolving asset IDs through the API and mounting a token into every build, which also breaks a plain local `docker build`. Since 11 of 14 jobs succeeded while three were refused, cutting the simultaneous draw is the cheaper lever to try first. |
| No automatic rerun of failed build jobs | A `workflow_run` companion calling `rerun-failed-jobs` would cover every transient failure, including the cosign install on `main`. It also masks genuine breakages and delays the red signal by two full attempts, so it is deliberately left out. It remains the answer if publish builds keep flaking. |
| `chore:` title, despite touching seven applications at once | `AGENTS.md` keeps a pull request to one application because release-please attributes a commit to a package by the files it touches. A `feat` or `fix` title here would write a changelog entry into all seven and release all seven. The images are byte-identical, so `chore:` correctly releases nothing. |

## Rollback Plan

Revert this pull request via GitHub's Revert button. No images change, and nothing is released, so no application version needs unwinding.

## Test plan

**Verifiable by agent before merging**

- [x] Built notifiarr for aarch64 natively with the new flags — `docker build --platform linux/arm64 --build-arg BUILD_ARCH=aarch64 --build-arg BUILD_VERSION=1.0.0 -t notifiarr-test .` downloaded the asset and produced an image.
- [x] Confirmed a wrong asset URL still fails rather than being masked by the retries, so the wrong-URL trap `AGENTS.md` warns about still surfaces as a build failure.
- [x] Confirmed the cosign change works end to end. [Run 31634365526](https://github.com/kanso-labs/home-assistant-applications/actions/runs/31634365526) rebuilt all seven applications across both architectures, and no job logged a cosign install. Its three failures were all release downloads, quoted in Evidence above, and are what the retry window and concurrency cap were then sized against.
- [x] A green Build run on the current head. [Run 31636142855](https://github.com/kanso-labs/home-assistant-applications/actions/runs/31636142855) built all eight applications across both architectures with the widened window and the concurrency cap in place — 16 of 16 image jobs green, including the three that failed the run before. An [earlier run](https://github.com/kanso-labs/home-assistant-applications/actions/runs/31634880177) was equally green at three lanes rather than two.

**Cannot be verified before merge**

- [ ] Confirm a publishing build still installs cosign and signs the image it pushes — the `publish: true` path only runs on a push to `main`, which cannot happen before this merges.
