### PR TITLE
ci: fail the build when an application's release wiring is broken

### DIFF
--- a/.github/scripts/verify-release-wiring.sh
+++ b/.github/scripts/verify-release-wiring.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Verifies that every application is wired into release-please correctly.
+#
+# Two annotations and two registrations hold the release chain together, and
+# none of them fails loudly on its own. An application with a missing piece
+# simply stops receiving updates, and nobody notices until someone checks by
+# hand. This is that check.
+#
+# Run from the repository root.
+
+set -euo pipefail
+
+config='release-please-config.json'
+manifest='.release-please-manifest.json'
+
+failures=0
+
+fail() {
+  printf '  ✗ %s\n' "$1" >&2
+  failures=$((failures + 1))
+}
+
+for path in */config.yaml; do
+  app="${path%/config.yaml}"
+  printf '%s\n' "${app}"
+
+  # The annotation marks the line release-please rewrites. Without it the
+  # version is never bumped, so Home Assistant is never offered the update.
+  if ! grep -qE '^version:.*#[[:space:]]*x-release-please-version' "${path}"; then
+    fail "${path} has no '# x-release-please-version' on its version line"
+  fi
+
+  if ! jq -e --arg a "${app}" '.packages | has($a)' "${config}" > /dev/null; then
+    fail "${app} is not registered in ${config}"
+    continue
+  fi
+
+  # The object form selects release-please's annotation-only updater. The bare
+  # string form runs a YAML round-trip that strips every comment in the file,
+  # including the annotation checked above.
+  if ! jq -e --arg a "${app}" '
+        .packages[$a]["extra-files"] // []
+        | any(type == "object" and .path == "config.yaml" and .type == "generic")
+      ' "${config}" > /dev/null; then
+    fail "${app} must declare extra-files as {\"path\": \"config.yaml\", \"type\": \"generic\"} in ${config}; the bare string form strips comments on release"
+  fi
+
+  if ! jq -e --arg a "${app}" 'has($a)' "${manifest}" > /dev/null; then
+    fail "${app} is not registered in ${manifest}"
+  fi
+done
+
+# A package naming a directory that no longer exists silently releases nothing.
+while read -r app; do
+  if [[ ! -f "${app}/config.yaml" ]]; then
+    fail "${config} lists '${app}', which has no ${app}/config.yaml"
+  fi
+done < <(jq -r '.packages | keys[]' "${config}")
+
+if ((failures > 0)); then
+  printf '\n%s release wiring problem(s) found.\n' "${failures}" >&2
+  exit 1
+fi
+
+printf '\nEvery application is wired into release-please correctly.\n'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -43,13 +43,29 @@ jobs:
         with:
           path: './${{ matrix.path }}'
 
+  verify:
+    name: Verify release wiring
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7.0.1
+
+      - name: Verify release wiring
+        run: ./.github/scripts/verify-release-wiring.sh
+
   # One job with a fixed name for branch protection to require. The linter runs
   # once per application, so its own check names change whenever an application
   # is added, and a forgotten name fails silently by never being required.
+  #
+  # The name predates the release wiring check and is left alone deliberately:
+  # it is the name branch protection asks for, and renaming it would stop the
+  # rule matching anything without saying so.
   confirm:
     name: Confirm lint succeeded
     runs-on: ubuntu-latest
-    needs: lint
+    needs:
+      - lint
+      - verify
     if: always()
     steps:
       - name: Check the lint result
@@ -58,5 +74,14 @@ jobs:
         run: |
           if [[ "${RESULT}" != 'success' ]]; then
             echo "At least one application failed linting (${RESULT})."
+            exit 1
+          fi
+
+      - name: Check the release wiring result
+        env:
+          RESULT: ${{ needs.verify.result }}
+        run: |
+          if [[ "${RESULT}" != 'success' ]]; then
+            echo "Release wiring verification failed (${RESULT})."
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,15 @@ architecture you are actually on — see Traps.
 **Run `npx prettier --check`** over the application directory. Prettier formats
 YAML, JSON and Markdown here, and CI checks it.
 
+**Verify the release wiring**, which catches a registration you forgot in step 6
+and an annotation you dropped:
+
+```shell
+./.github/scripts/verify-release-wiring.sh
+```
+
+CI runs this too, as `Verify release wiring`.
+
 ## Conventions
 
 ### Key ordering
@@ -245,6 +254,10 @@ one by the files it touches, so a change under `radarr/` releases Radarr alone.
 
 Neither produces an error when missing. The application simply stops receiving
 updates, and nobody notices until someone checks.
+
+`.github/scripts/verify-release-wiring.sh` is that check for the first one, and
+for the registrations in step 6. It runs in CI as `Verify release wiring`.
+Nothing yet guards the Renovate annotation.
 
 ## Traps
 


### PR DESCRIPTION
## Summary

Adds a CI check that fails the build when an application's release wiring is broken, so a mistake that would silently stop that application from ever updating is caught at review time instead of by somebody noticing months later.

Before this change, nothing in CI looked at the annotations or registrations that make releases work. A broken one produced no error anywhere — the application just quietly stopped being released.

This is the follow-up promised in [#75](https://github.com/kanso-labs/home-assistant-applications/pull/75).

## Problem

Four things have to be true for an application to keep reaching users, and not one of them fails loudly on its own:

- `# x-release-please-version` sits beside `version` in `config.yaml`, marking the line release-please rewrites.
- The application is registered in `release-please-config.json`.
- That registration uses the object form of `extra-files`, not the bare string.
- The application is registered in `.release-please-manifest.json`.

Miss any one and the version never moves. Home Assistant decides an update exists by comparing `config.yaml`'s version against the installed one, so an application whose version is frozen never offers an update no matter how many images get built for it.

The failure is invisible by construction. That is how the comment stripping ran for seven consecutive releases before anyone spotted it.

**The third item is new and already has a near miss.** [#75](https://github.com/kanso-labs/home-assistant-applications/pull/75) moved every package to the object form, which drops release-please's jsonpath fallback — a missing annotation used to still get bumped via `$.version`, and now does not. In the same window, Notifiarr arrived in the config with the old string form from [#74](https://github.com/kanso-labs/home-assistant-applications/pull/74), because the pull request that added it had no reason to know about the one changing the convention. Copying an older entry is exactly the mistake review does not catch, and it was caught only because a rebase happened to put the two side by side.

## Solution

A single repository-wide check now runs in the Lint workflow as `Verify release wiring`, and it reports every problem it finds rather than stopping at the first.

It runs once for the repository rather than per application, because the questions it asks are about the relationship between the applications and the two release-please files. It also checks the reverse direction: a package naming a directory that no longer exists releases nothing, and nothing else would notice.

The new job reports into the existing `Confirm lint succeeded` job rather than adding a check name of its own.

## Evidence

A guard that never fires is worthless, so each way the wiring can break was reproduced against an isolated copy and run through the real script:

```
baseline
  PASS  unmodified repo should pass                exit=0

failure modes
  PASS  annotation stripped from a config          exit=1
        ✗ radarr/config.yaml has no '# x-release-please-version' on its version line
  PASS  package reverted to bare string form       exit=1
        ✗ bazarr must declare extra-files as {"path": "config.yaml", "type": "generic"} ...
  PASS  application missing from release config    exit=1
        ✗ notifiarr is not registered in release-please-config.json
  PASS  application missing from manifest          exit=1
        ✗ nzbget is not registered in .release-please-manifest.json
  PASS  stale package with no directory            exit=1
        ✗ release-please-config.json lists 'ghostapp', which has no ghostapp/config.yaml
  PASS  new application not registered anywhere    exit=1
        ✗ newapp is not registered in release-please-config.json
```

## Review Guide

No call-flow tree applies — one script, one workflow job, and a documentation update.

- **`.github/scripts/verify-release-wiring.sh`** — the whole change. Worth reading for what it does *not* catch, since anything missing here stays invisible in exactly the way the Problem describes.
- **`.github/workflows/lint.yaml`** — the `confirm` job now gates on two upstream jobs. Its `if: always()` matters: without it a failed `verify` would skip the gate rather than fail it.

The job runs a script from the checked-out workspace. The Lint workflow triggers on `pull_request`, not `pull_request_target`, with `permissions: contents: read` — the same trust model the application linter and the Docker build already run under, so head code gains no privilege and sees no secrets.

## Design Decisions

| Decision | Context |
|---|---|
| Report into `Confirm lint succeeded` rather than add a required check | That job exists because the per-application linter's check names change whenever an application is added, so branch protection has one fixed name to require. A new required check would need the branch protection rule updated by hand, and would fail open until someone did. |
| Leave `Confirm lint succeeded` named as it is | The name is now narrower than what the job covers, which is a real wart. Renaming it would stop the branch protection rule matching anything, without announcing that it had — a two-step change that has to add the new name to branch protection first. Worth doing later, and it is your call. |
| A shell script rather than inline workflow YAML | The script can be run locally, which is what let every failure mode above be proven before merge. It is also the thing AGENTS.md can tell the next agent to run in step 7, rather than describing checks nobody can execute. |

## Rollback Plan

Revert via GitHub's Revert button. The check is advisory to everything except the branch protection gate, and nothing else depends on it.

## Test plan

**Verifiable by agent before merging**
- [x] Reproduced all six failure modes against an isolated copy and confirmed each exits non-zero with a message naming the application and the fix — output above
- [x] Confirmed the unmodified repository passes, so the check is not failing open or failing everything
- [x] `shellcheck` clean and `bash -n` syntax clean
- [x] Workflow YAML parses, and the job graph is `find` → `lint` + `verify` → `confirm` with `confirm` needing both
- [x] The script's executable bit is recorded in git as mode `100755`, without which the CI step would not run
- [x] `prettier --check` passes on the workflow and AGENTS.md
- [x] The `Verify release wiring` job passes on this pull request in [run 31634682749](https://github.com/kanso-labs/home-assistant-applications/actions/runs/31634682749) — the live end-to-end proof, and `Confirm lint succeeded` passed alongside it, so the new job reaches the gate rather than being skipped

**Cannot be verified before merge**
- [ ] That a failing check actually blocks the merge — that depends on the branch protection rule requiring `Confirm lint succeeded`, which is repository settings rather than anything in this diff
