### PR TITLE
fix(bazarr): pin to a Python version Bazarr supports

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,6 +39,11 @@
       "matchUpdateTypes": ["minor", "patch"]
     },
     {
+      "allowedVersions": "<3.14",
+      "description": "Bazarr supports Python 3.13 and below, and says so on startup when it is given anything newer. It is the only application on base-python, so the ceiling can sit on the image itself.",
+      "matchPackageNames": ["ghcr.io/home-assistant/base-python"]
+    },
+    {
       "groupName": "Home Assistant Base Images",
       "matchPackageNames": ["ghcr.io/home-assistant/**"]
     },

--- a/bazarr/Dockerfile
+++ b/bazarr/Dockerfile
@@ -1,5 +1,8 @@
 # https://developers.home-assistant.io/docs/apps/configuration#app-dockerfile
-ARG BUILD_FROM=ghcr.io/home-assistant/base-python:3.14-alpine3.22
+# Bazarr supports Python 3.13 and below. It starts on 3.14 and then says so
+# itself: "Python version greater than 3.13.x is unsupported [...] you're on
+# your own". Renovate is held to 3.13 for this image; see renovate.json.
+ARG BUILD_FROM=ghcr.io/home-assistant/base-python:3.13-alpine3.22
 FROM ${BUILD_FROM}
 
 # Set shell


### PR DESCRIPTION

## Summary

Fixes Bazarr running on a Python version its own developers do not support, caused by [#65](https://github.com/kanso-labs/home-assistant-applications/pull/65) automerging a base-image bump from `3.12-alpine3.22` to `3.14-alpine3.22`, by pinning the image to `3.13-alpine3.22` and giving Renovate a ceiling below 3.14.

Before this change the container started on Python 3.14.6 and logged Bazarr's own unsupported-version warning on every boot. It now starts on 3.13 and the warning is gone.

## Problem

The 3.12 pin was deliberate, and Renovate replaced it with 3.14 under the existing minor and patch automerge rule. Bazarr supports Python 3.13 and below.

Nothing failed, which is why this reached `main` unnoticed. Bazarr starts on 3.14 and serves requests, and CI builds the image without ever booting it, so every signal stayed green.

The cost is not a crash. It is that upstream will not take bug reports from an unsupported interpreter, and nothing guarantees the behaviour stays working.

## Evidence

From booting the current `main` image on `aarch64`:

```
[17:51:10] INFO: Starting Bazarr...
Python version greater than 3.13.x is unsupported. Current version is 3.14.6. Keep in mind that even if it works, you're on your own.
...
BAZARR is started and waiting for requests on: http://[::]:6767
```

That same boot answered HTTP 200. The defect is the unsupported interpreter, not a failure to start.

## Solution

The image is pinned to the newest Python Bazarr actually supports, and Renovate is stopped from undoing it.

- **`bazarr/Dockerfile`** now builds from `ghcr.io/home-assistant/base-python:3.13-alpine3.22`. I checked the registry directly: `3.12-alpine3.22`, `3.13-alpine3.22`, `3.13-alpine3.23` and `3.14-alpine3.22` all exist, so 3.13 is available rather than assumed. A comment above the `ARG` records why the ceiling exists.
- **`.github/renovate.json`** gains a rule holding `ghcr.io/home-assistant/base-python` to `<3.14`. Without it Renovate raises 3.14 again and the minor and patch automerge rule merges it again, reproducing exactly this situation.

The ceiling sits on the image rather than on the application because Bazarr is the only application built on `base-python` — it is the sole `Dockerfile` in the repository that matches.

## Review Guide

```
bazarr/Dockerfile          ← the pin itself, plus the comment explaining it
.github/renovate.json      ← the ceiling that keeps the pin from being undone
```

**Focus areas**

- **`.github/renovate.json`** — the rule is the load-bearing half. If `matchPackageNames` does not match the image in practice, the ceiling silently does nothing, Renovate re-raises 3.14, and automerge lands it. That silent-no-op path is the exact failure mode that produced this pull request, and it would look identical from the outside.

## Blast Radius

Not behind a feature flag. It changes the interpreter inside the Bazarr image, so it reaches Bazarr users on the next release and touches no other application.

## Rollback Plan

Revert via GitHub's Revert button. Nothing is published until a release pull request merges.

## Test plan

**Verifiable by agent before merging**

- [x] Reproduced on current `main`: built for `aarch64`, booted, and captured the unsupported-version warning quoted above alongside an HTTP 200 response.
- [x] Verified on this branch: built for `aarch64`, booted, `BAZARR is started and waiting for requests on: http://[::]:6767`, HTTP 200, and no unsupported-version warning. No new errors or tracebacks in the log.
- [x] Confirmed `3.13-alpine3.22` exists in the registry rather than assuming the tag.
- [x] Confirmed Bazarr is the only application built on `base-python`, which is what makes an image-scoped ceiling correct.
- [x] `npx prettier --check` passes on `.github/renovate.json`. Prettier has no Dockerfile parser, so the Dockerfile is not covered by it.

**Cannot be verified before merge**

- [ ] Boot on `amd64` — an amd64 image cannot be booted on this arm64 host, so CI's native runner is the first place it runs.
- [ ] Confirm Renovate's next run does not re-raise 3.14 — requires a Renovate cycle against `main` after this merges.
