### PR TITLE
chore(notifiarr): restore the comments release-please stripped

### DIFF
--- a/notifiarr/config.yaml
+++ b/notifiarr/config.yaml
@@ -2,15 +2,20 @@ arch:
   - aarch64
   - amd64
 backup: cold
-description: >-
+description:
   Unified client for Notifiarr.com. Notifiarr reports on the applications you
   run and lets Discord drive content requests, media reports and system health
   checks.
-image: ghcr.io/kanso-labs/home-assistant-application-notifiarr
+image: 'ghcr.io/kanso-labs/home-assistant-application-notifiarr'
 init: false
 map:
+  # Supervisor deprecated `addon_config` for `app_config` in 2026.07, but
+  # frenck/action-addon-linter still only accepts the older spelling and has
+  # had no release since 2025-11. Home Assistant's own apps-example runs the
+  # same linter. Switch this once the linter's schema catches up.
   - read_only: false
     type: addon_config
+  # Notifiarr reports free space on the storage it can see, and never writes.
   - read_only: true
     type: share
 name: Notifiarr
@@ -23,6 +28,6 @@ ports_description:
 schema:
   api_key: password?
 slug: notifiarr
-url: https://github.com/kanso-labs/home-assistant-applications/tree/main/notifiarr
-version: 1.1.0
-webui: http://[HOST]:[PORT:5454]
+url: 'https://github.com/kanso-labs/home-assistant-applications/tree/main/notifiarr'
+version: '1.1.0' # x-release-please-version
+webui: 'http://[HOST]:[PORT:5454]'


### PR DESCRIPTION
## Summary

Restores the comments that releasing Notifiarr 1.1.0 stripped from `notifiarr/config.yaml`, including the `# x-release-please-version` annotation, without which the application would never be offered another update.

`main` currently fails its own `Verify release wiring` check because of this. Since that check feeds `Confirm lint succeeded`, and the ruleset on `main` requires it, nothing can merge until this lands.

## Problem

Notifiarr was added and released before the `extra-files` object form reached `release-please-config.json`. Its release therefore went through the old bare-string updater, which parses `config.yaml` and writes it back out — dropping every comment in the file and the quoting with it.

Running the verifier on `main` shows it:

```
notifiarr
  ✗ notifiarr/config.yaml has no '# x-release-please-version' on its version line

1 release wiring problem(s) found.
```

Two things were lost. The annotation marks the line release-please rewrites, so without it the version is never bumped and Home Assistant is never told there is an update. The note in `map:` records why the spelling is still `addon_config`, which is the thing that stops someone "fixing" it to `app_config` and breaking the linter.

The file is now the only application config carrying no comments at all.

## Solution

Restores the file as it was written when Notifiarr was added, carrying only the version forward to `1.1.0` so it matches the manifest. That puts back both comments, the annotation, and the original quoting, and leaves the file consistent with every sibling application.

This is a `chore`, so it releases nothing. Nothing users can see changed, and the version it declares is the one already released.

The underlying cause is already fixed: `release-please-config.json` now declares `extra-files` in the object form for every application, which selects the annotation-only updater and leaves comments alone. Notifiarr was simply released in the window before that landed.

## Test plan

**Verifiable by agent before merging**

- [x] `./.github/scripts/verify-release-wiring.sh` passes, where it exits 1 on `main` — "Every application is wired into release-please correctly."
- [x] `npx prettier --check notifiarr/config.yaml` clean.
- [x] The only change to the version line is the annotation and quoting. The value stays `1.1.0`, matching `.release-please-manifest.json`.

**Cannot be verified before merge**

- [ ] That Notifiarr's next release bumps the version in place and keeps the comments — it needs a release to run against the restored file.
