### PR TITLE
chore(notifiarr): restore the comments its release stripped

### DIFF
--- a/notifiarr/config.yaml
+++ b/notifiarr/config.yaml
@@ -2,15 +2,20 @@ arch:
   - aarch64
   - amd64
 backup: cold
-description: >-
+description:
   Unified client for Notifiarr.com. Notifiarr reports on the applications you
   run and lets Discord drive content requests, media reports and system health
   checks.
-image: ghcr.io/kanso-labs/home-assistant-application-notifiarr
+image: 'ghcr.io/kanso-labs/home-assistant-application-notifiarr'
 init: false
 map:
+  # Supervisor deprecated `addon_config` for `app_config` in 2026.07, but
+  # frenck/action-addon-linter still only accepts the older spelling and has
+  # had no release since 2025-11. Home Assistant's own apps-example runs the
+  # same linter. Switch this once the linter's schema catches up.
   - read_only: false
     type: addon_config
+  # Notifiarr reports free space on the storage it can see, and never writes.
   - read_only: true
     type: share
 name: Notifiarr
@@ -23,6 +28,6 @@ ports_description:
 schema:
   api_key: password?
 slug: notifiarr
-url: https://github.com/kanso-labs/home-assistant-applications/tree/main/notifiarr
-version: 1.1.0
-webui: http://[HOST]:[PORT:5454]
+url: 'https://github.com/kanso-labs/home-assistant-applications/tree/main/notifiarr'
+version: '1.1.0' # x-release-please-version
+webui: 'http://[HOST]:[PORT:5454]'


### PR DESCRIPTION
## Summary

Fixes Notifiarr being unable to release at all, caused by its 1.1.0 release landing a `config.yaml` stripped of the `# x-release-please-version` annotation, by restoring the file's comments with the released version carried forward.

Before this change, `main` carried a Notifiarr config whose version line no release could ever touch again. It now carries the annotation release-please needs, and `main`'s [failing lint run](https://github.com/kanso-labs/home-assistant-applications/actions/runs/31637116123) goes green.

The version value is unchanged at `1.1.0`, so no installed instance sees anything move.

## Problem

`main` is red. The `Verify release wiring` job has failed on every run since the Notifiarr release merged, and every pull request opened against `main` inherits that failure.

The build being red is the smaller half. **Notifiarr can no longer be released.** Its config now reads `version: 1.1.0` with no annotation and no comments, and since [#75](https://github.com/kanso-labs/home-assistant-applications/pull/75) every package uses release-please's annotation-only updater — it edits the line carrying the annotation and nothing else.

There is no fallback any more. The jsonpath bump that used to move `$.version` regardless was deliberately dropped in that same pull request. So the version would sit at `1.1.0` through every future release, and since Home Assistant decides an update exists by comparing that value against the installed one, it would never offer another update. Nothing would report an error at any point.

Two comments went with it. One records that `addon_config` is deliberate, because the linter still rejects the current spelling. The other records that the share mount is read-only because Notifiarr reports free space and never writes.

## Evidence

The guard added in [#79](https://github.com/kanso-labs/home-assistant-applications/pull/79) caught this on its first real exposure, with nobody looking:

```
notifiarr
  ✗ notifiarr/config.yaml has no '# x-release-please-version' on its version line

1 release wiring problem(s) found.
```

That is the failure it was built for. Without it, this surfaces whenever somebody eventually wonders why Notifiarr stopped updating.

## Solution

Restores the config to its pre-release formatting, keeping the version at `1.1.0`.

The comments come back, the scalars regain their quoting, and the `options`, `schema` and `ports` data is untouched. Nothing is rebuilt and nothing is published.

## How this reached `main`

Worth recording, because nothing stops it happening again.

Release pull request [#76](https://github.com/kanso-labs/home-assistant-applications/pull/76) was opened *before* the comment-stripping fix merged, so its branch already held the re-serialised file. release-please does not regenerate an open release pull request when only file contents would differ — on its next run it compared by title and body, found them identical, and logged:

```
✔ PR .../pull/76 remained the same
```

Merging it then put the stale file on `main`. The hazard was flagged on #75 before that merge, with the recommendation to close and regenerate #76 instead.

## Design Decisions

| Decision | Context |
|---|---|
| Repair the file by hand rather than let the next release fix it | The obvious alternative is to leave it and let Notifiarr's next release rewrite the version line properly. That is exactly what cannot happen: the missing annotation is what stops any future release from touching that line, so waiting means waiting forever. |
| Carry the version forward at `1.1.0` rather than revert to `1.0.0` | The 1.1.0 release genuinely happened and its image is published. Only the file bookkeeping was damaged, so the version has to stay where the manifest and the published image already are. |

## Rollback Plan

Revert via GitHub's Revert button. That returns `main` to a red build and leaves Notifiarr unable to release, so a revert only makes sense alongside a different repair.

## Test plan

**Verifiable by agent before merging**
- [x] `./.github/scripts/verify-release-wiring.sh` passes for all eight applications, having failed on Notifiarr before this change with the message quoted above
- [x] `prettier --check` passes on the file
- [x] The diff is confined to comments and scalar quoting — the version value stays `1.1.0`, and the `options`, `schema` and `ports` data is unchanged

**Cannot be verified before merge**
- [ ] A future Notifiarr release bumps the version line and leaves the comments intact — requires release-please to run against `main` after a releasing commit for Notifiarr merges

## Follow-up

Nothing prevents a repeat. Any release pull request opened before a change that affects `config.yaml` will keep serving its stale copy, and merging it re-lands the damage. The durable habit is to close and regenerate a stale release pull request rather than merge it, and nothing enforces that today.
