### PR TITLE
ci: auto-merge the release pull requests once their checks pass

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -29,3 +29,25 @@ jobs:
         uses: googleapis/release-please-action@v5.0.0
         with:
           token: ${{ steps.token.outputs.token }}
+
+      # Auto-merge only queues when something is already blocking the pull
+      # request, which here is the ruleset requiring the two Confirm checks.
+      # Remove that rule and this stops waiting for anything: --auto on an
+      # unblocked pull request merges it on the spot.
+      #
+      # Failing to enable it is not worth failing the run over. The release
+      # pull request itself is already open and correct, and merging it by hand
+      # still works, so this warns and moves on.
+      - name: Enable auto-merge on the release pull requests
+        if: steps.release.outputs.prs != '' && steps.release.outputs.prs != '[]'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          PRS: ${{ steps.release.outputs.prs }}
+        run: |
+          jq -r '.[].number' <<< "${PRS}" | while read -r pr; do
+            if gh pr merge --auto --squash "${pr}"; then
+              echo "Auto-merge enabled on #${pr}."
+            else
+              echo "::warning::Could not enable auto-merge on #${pr}. Merge it by hand."
+            fi
+          done


### PR DESCRIPTION
## Summary

Adds auto-merge to the release pull requests release-please raises, so a release lands once its checks pass instead of waiting for somebody to press merge.

Every release until now has sat green until a person noticed it. Nothing else in the chain needs attention: Renovate raises the bump, release-please raises the release, and merging it publishes the image. The merge was the only manual link.

This is the last step of the work started in [#73](https://github.com/kanso-labs/home-assistant-applications/pull/73), and it depends on the ruleset that landed after it.

## Problem

Releasing an application is what makes Home Assistant offer the update to an installed instance. Until the release pull request merges, a bump that Renovate found and release-please wrote up reaches nobody.

Those pull requests have been sitting open until someone happened to look. The delay is invisible — nothing is red, nothing is waiting on a decision, the release simply has not happened yet.

## Solution

After proposing releases, the workflow enables auto-merge on each pull request release-please reports, using the same application token it already mints. GitHub then merges it when the required checks go green, or leaves it alone if they do not.

Two details are worth the reviewer's attention.

**It keys off `prs` rather than `prs_created`.** The latter is only true on the run that creates a pull request, so a release that was proposed earlier and merely updated on this run would never have auto-merge switched on.

**Failing to enable it warns rather than fails the run.** By the time this step runs the release pull request is already open and correct, and merging by hand still works. The common case for a failure here is re-running against a pull request that already has auto-merge enabled, which is not worth a red workflow.

**The required checks are load-bearing, not incidental.** Auto-merge only queues while something is blocking the pull request. With no required check, `--auto` merges immediately — releasing before anything has run, which is worse than the manual step it replaces. The ruleset requiring `Confirm lint succeeded` and `Confirm builds succeeded` is what makes this safe, and the workflow carries a comment saying so, because the failure mode of removing that rule is silent.

That ordering is also why this is a separate pull request rather than part of [#73](https://github.com/kanso-labs/home-assistant-applications/pull/73): the ruleset could not exist until those two jobs had reported at least once.

## Dependencies

Blocked behind [#82](https://github.com/kanso-labs/home-assistant-applications/pull/82), and so is everything else.

`main` currently fails its own `Verify release wiring` check. Releasing Notifiarr 1.1.0 stripped the `x-release-please-version` annotation out of its `config.yaml`, and that check feeds `Confirm lint succeeded`, which the ruleset requires. Nothing merges until it lands.

## Rollback Plan

Revert this pull request. Release pull requests go back to being raised and left open for a human to merge, which is how they behaved before.

Disabling auto-merge on a single pull request that has it queued does not need a revert — `gh pr merge --disable-auto <number>` is enough.

## Test plan

**Verifiable by agent before merging**

- [x] `actionlint` clean on the changed workflow.
- [x] `npx prettier --check` clean.
- [x] The parsing was dry-run against a realistic `prs` payload. Two pull request objects yield exactly their two numbers, and both an empty string and `[]` skip the step rather than running it against nothing.

**Cannot be verified before merge**

- [ ] That a release pull request actually merges itself — it needs release-please to raise one on `main`, which cannot happen from a branch.
- [ ] The `skipped` path of `Confirm builds succeeded`, which no run has exercised yet. Every check so far touched an application or a workflow file and took the `success` path. A release pull request touches only a changelog, a version, and the manifest, so the build is skipped and the gate has to read that as a pass. If it does not, the release sits blocked instead of merging — the safe direction, but the first thing to look at.
