### PR TITLE
ci: point gh at the repository when enabling auto-merge

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -42,6 +42,7 @@ jobs:
         if: steps.release.outputs.prs != '' && steps.release.outputs.prs != '[]'
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
           PRS: ${{ steps.release.outputs.prs }}
         run: |
           jq -r '.[].number' <<< "${PRS}" | while read -r pr; do


### PR DESCRIPTION
## Summary

Fixes auto-merge never being enabled on release pull requests, caused by `gh` having no checkout to infer the repository from in the [Release Please](.github/workflows/release-please.yaml) job, by passing the repository through `GH_REPO` instead.

Since the auto-merge step was added, every release pull request has opened with auto-merge off and waited for a human. They now have it enabled the moment release-please opens them.

## Problem

[#86](https://github.com/kanso-labs/home-assistant-applications/pull/86) opened with `autoMergeRequest: null` while being `MERGEABLE` and `CLEAN` — nothing was blocking it, and nothing merged it. That is every release pull request since the step landed, not one unlucky case.

The `release-please` job never checks the repository out, because `release-please-action` talks to the API directly and does not need a working tree. So `gh pr merge --auto --squash "${pr}"` had no git remote to resolve the repository from and exited before it did anything.

The step catches its own failure and warns rather than failing the run, which is the right call for a release that is already open and correct. It also meant the warning scrolled past in a green run and nobody noticed.

## Evidence

From the run that opened [#86](https://github.com/kanso-labs/home-assistant-applications/pull/86), [run 31638679845](https://github.com/kanso-labs/home-assistant-applications/actions/runs/31638679845):

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git

##[warning]Could not enable auto-merge on #86. Merge it by hand.
```

Repository settings were ruled out as a cause and are unchanged by this pull request — `allow_auto_merge` and `allow_squash_merge` are both already true.

## Solution

`gh` now takes the repository from the environment rather than from a checkout that was never there, via `GH_REPO: ${{ github.repository }}` alongside the existing `GH_TOKEN`.

One line, and no checkout step. Adding `actions/checkout` would also have worked and would have cost a clone on every push to `main` to satisfy a single API call.

## Test plan

**Verifiable by agent before merging**

- [x] Confirmed the failure and its cause in [run 31638679845](https://github.com/kanso-labs/home-assistant-applications/actions/runs/31638679845)
- [x] Confirmed the repository allows auto-merge and squash merges, so settings are not a second cause
- [x] `npx prettier --check .github/workflows/release-please.yaml`

**Cannot be verified before merge**

- [ ] The next release pull request opens with auto-merge enabled — `Release Please` runs only on `push` to `main`, so the changed step cannot execute from a pull request and proves itself on the first release proposed after this lands

Worth noting for whoever merges: the step's comment says auto-merge waits on a ruleset requiring two Confirm checks, but [#86](https://github.com/kanso-labs/home-assistant-applications/pull/86) is already `CLEAN`, so `--auto` will merge release pull requests on the spot rather than waiting. That is the intended outcome here, but the comment now overstates what is gating them.

The `ci:` title releases nothing, which is deliberate — this touches no application.
