### PR TITLE
feat(flaresolverr): give it an entry in Home Assistant

### DIFF
--- a/flaresolverr/DOCS.md
+++ b/flaresolverr/DOCS.md
@@ -9,21 +9,31 @@
 
 ## Connecting Prowlarr
 
-FlareSolverr has no interface of its own. It answers requests on port 8191 and
-is driven entirely by the application in front of it.
-
 In Prowlarr, go to **Settings → Indexers → Add Indexer Proxy → FlareSolverr**
-and set the host to:
+and set the host to your Home Assistant machine's address:
 
 ```
-http://<your-home-assistant-host>:8191
+http://192.168.1.10:8191
 ```
+
+**Replace the address Prowlarr suggests.** It defaults to
+`http://localhost:8191/`, which cannot work here. Every application runs in its
+own container, so `localhost` means Prowlarr itself rather than FlareSolverr.
+The symptom is a proxy that refuses to connect while FlareSolverr sits there
+running perfectly.
+
+**Do not add `/v1` to the end.** Prowlarr appends it, and a host that already
+ends in `/v1` becomes `/v1/v1` and fails.
 
 Give the proxy a tag, then apply that same tag to each indexer that needs it.
 Only tagged indexers are routed through FlareSolverr.
 
 Radarr, Sonarr and Bazarr reach it the same way if they talk to indexers
 directly.
+
+Ingress will not do for this. It serves through Home Assistant's authenticated
+proxy, which Prowlarr cannot sign in to, so the address above is the only route
+in.
 
 ## Configuration
 
@@ -39,8 +49,23 @@ mapped and nothing survives a restart. There is nothing to back up.
 
 ## Checking it works
 
-Opening `http://<host>:8191` in a browser returns a short JSON message rather
-than a page. That is the health response, and seeing it means the service is up.
+FlareSolverr has no interface. Opening it from Home Assistant shows a short JSON
+message rather than a page, and that message is the health response:
+
+```json
+{ "msg": "FlareSolverr is ready!", "version": "3.5.0", "userAgent": "..." }
+```
+
+Seeing it means the service is up. The same response comes back from the address
+Prowlarr uses, which is the quicker way to tell a connection problem from an
+application problem:
+
+```shell
+curl http://192.168.1.10:8191
+```
+
+If that answers and Prowlarr still cannot connect, the address in Prowlarr is
+wrong rather than FlareSolverr being down.
 
 ## Updating
 

--- a/flaresolverr/config.yaml
+++ b/flaresolverr/config.yaml
@@ -6,6 +6,8 @@ description:
   and their indexers. Prowlarr and the rest send a request through FlareSolverr
   and get the answer back.
 image: 'ghcr.io/kanso-labs/home-assistant-application-flaresolverr'
+ingress: true
+ingress_port: 8191
 init: false
 name: FlareSolverr
 options:


### PR DESCRIPTION
## Summary

Gives FlareSolverr an entry in Home Assistant so an installed application stops looking broken, by enabling ingress, and documents the address Prowlarr needs so its default one stops being tried.

Before this change the application had nothing to open at all. It now opens from Home Assistant and shows its health response, which is the only thing FlareSolverr has to show.

The published port is unchanged, and it has to be: ingress cannot carry Prowlarr's requests.

Both problems here were reported after installing [#91](https://github.com/kanso-labs/home-assistant-applications/pull/91). Omitting the entry point was my call in that pull request, and it read as broken exactly as reported.

## Problem

Two complaints, and they are unrelated to each other despite arriving together.

**Nothing to open.** [#91](https://github.com/kanso-labs/home-assistant-applications/pull/91) omitted both `ingress` and `webui` on the grounds that port 8191 answers with JSON rather than a page, so an "Open Web UI" button would land on raw JSON. That judged what the button shows and ignored what its absence says. An application with no entry point looks like it failed to install, whatever it is doing underneath.

**Prowlarr would not connect.** Prowlarr ships `http://localhost:8191/` as the default host for its FlareSolverr proxy. Every application here runs in its own container, so from inside Prowlarr that address is Prowlarr itself and the default can never work.

The failure mode is what makes this worth documenting rather than shrugging at. Prowlarr reports a proxy that refuses to connect while FlareSolverr sits beside it running perfectly, so the evidence points at the wrong application.

The documentation in #91 gave the right address but never said the suggested default was a trap.

## Solution

**Ingress is enabled**, with the port kept published alongside it.

The two serve different callers and both are needed. Ingress is for a person opening the application from Home Assistant. The published port is for Prowlarr, which cannot sign in to Home Assistant's authenticated proxy and therefore cannot reach the API through ingress at all.

Nothing in the file says so, so the pairing is worth knowing before touching either key.

**The documentation now names both ways to get the address wrong.** Prowlarr's default cannot work, and appending `/v1` breaks it too, because Prowlarr appends that itself and a host ending in `/v1` becomes `/v1/v1`. It also gives a `curl` against the same address as the fastest way to tell a connection problem from an application problem.

## Review Guide

- **`flaresolverr/config.yaml`** — ingress and the published port have to coexist, and nothing in the file explains why. Removing the port later looks like tidying up and would silently break every indexer routed through this.

## Design Decisions

| Decision | Context |
|---|---|
| Keep the published port alongside ingress | The tempting cleanup is to treat ingress as the way in and drop the port. Ingress is authenticated and browser-oriented, while Prowlarr is a service calling an API, so that cleanup would break the only thing this application exists to do. |
| Ingress rather than a plain Web UI button | A `webui` entry was the other option and opens a new tab on a raw JSON document. Ingress keeps the entry inside Home Assistant and is what the reference packaging does. Both show the same health response, since there is no interface to present either way. |

## Rollback Plan

Revert via GitHub's Revert button. The application goes back to running correctly with no way to open it, and Prowlarr is unaffected either way, since it never used ingress.

## Test plan

**Verifiable by agent before merging**
- [x] Rebuilt and booted on aarch64 after the change, reaching `Test successful!` and `Serving on http://0.0.0.0:8191` — the configuration change did not disturb startup
- [x] Sent a request carrying the headers Supervisor adds when proxying (`X-Ingress-Path`, `X-Forwarded-Proto`, `X-Forwarded-For`) and got HTTP 200 with the normal health JSON, so FlareSolverr tolerates being served behind the proxy rather than breaking on the path prefix
- [x] `config.yaml` validated against `frenck/action-addon-linter`'s own `config.schema.json` — `ingress` and `ingress_port` accepted, no unknown keys
- [x] `./.github/scripts/verify-release-wiring.sh` passes
- [x] `prettier --check` passes

**Cannot be verified before merge**
- [ ] The ingress entry appears and opens from the application page — requires an installed Supervisor instance
- [ ] Prowlarr connects once pointed at the host address — requires a live Prowlarr with an indexer configured
