### PR TITLE
fix(flaresolverr): stop Chromium failing to start

### DIFF
--- a/flaresolverr/rootfs/etc/chromium.d/dev-shm
+++ b/flaresolverr/rootfs/etc/chromium.d/dev-shm
@@ -1,0 +1,18 @@
+# Replaces the fragment Debian ships at this path.
+#
+# Chromium is launched through a wrapper script, and chromedriver reads that
+# process's stderr to finish starting the browser. Anything else written there
+# first breaks the handshake, and FlareSolverr reports that Chrome is not
+# reachable rather than anything about the output.
+#
+# Debian's version tests the space available on /dev/shm to decide whether to
+# add the flag below, and reads it unquoted. On a host where findmnt reports
+# more than one value the test writes "unexpected operator" to stderr, which is
+# enough to stop the browser starting. Quoting would not help: the test then
+# fails on a non-numeric argument and writes to stderr anyway.
+#
+# The flag is always wanted here, so the test is gone rather than corrected. A
+# container gets 64 MB of /dev/shm, Home Assistant offers no way to raise it,
+# and Chromium dies at startup without this.
+
+export CHROMIUM_FLAGS="$CHROMIUM_FLAGS --disable-dev-shm-usage"


### PR DESCRIPTION
## Summary

Fixes FlareSolverr crash-looping with "chrome not reachable", caused by a startup script writing an error to stderr where chromedriver expects only the browser's own output, by replacing the fragment that writes it.

Before this change the browser never started on affected hosts, so the application exited and s6 restarted it to fail the same way. It now starts and serves requests.

The failure is host-dependent, which is why the application worked here and not on the machine it was installed on.

## Problem

FlareSolverr never finishes starting on some hosts. The browser fails to launch, the application exits, and s6 brings it straight back to do the same thing again.

From the reported logs, the two lines that matter are far apart and only one of them looks relevant:

```
Chrome / Chromium path: /bin/chromium
/bin/chromium: 9: [: 8270786560: unexpected operator
...
Error starting Chrome: Message: session not created: cannot connect to chrome
at 127.0.0.1:53003 from chrome not reachable
Exception: Error getting browser User-Agent.
Service FlareSolverr exited with code 1
```

Chromium is launched through a wrapper script, and chromedriver reads that process's stderr to finish starting the browser. Anything written there first breaks the handshake, and the error that surfaces names the connection rather than the output that caused it.

The line comes from a fragment Debian ships at `/etc/chromium.d/dev-shm`, which decides whether to disable Chromium's use of shared memory:

```sh
shm_avail=$(findmnt -bnr -o avail -T /dev/shm)
if [ $shm_avail -lt 4080218931 ]  # 3.8 GB
```

On a host where `findmnt` reports more than one value, the unquoted expansion splits into several words and the test writes `unexpected operator`. That single line is enough.

## Evidence

The obvious reading is that the missing `--disable-dev-shm-usage` flag is the fault, since a container gets 64 MB of shared memory. That was tested and is wrong.

| Image | Flag present | Wrapper stderr | Result |
|---|---|---|---|
| Unmodified | yes | clean | `Test successful!` |
| Guard replaced with one that errors | no | one line | chrome not reachable |
| Same, plus a fragment restoring the flag | **yes** | one line | **chrome not reachable** |
| Unmodified, plus a fragment that only writes one line | yes | one line | **chrome not reachable** |

The third row is what rules the flag out. The real Chromium command line was dumped from both the working and failing images, and they were identical except that the working one carried `--disable-dev-shm-usage` twice:

```
working: ... --media-router=0 --disable-dev-shm-usage --enable-remote-extensions --load-extension= --disable-dev-shm-usage
failing: ... --media-router=0 --enable-remote-extensions --load-extension= --disable-dev-shm-usage
```

The fourth row isolates the cause. Taking the known-good image and adding a fragment that writes one line to stderr, changing no flag at all, reproduces the failure exactly.

## Solution

Ships a replacement for that fragment at the same path, so Debian's version never runs.

It sets the flag unconditionally and contains nothing that can write to stderr — the only executable line in the file is the export. The flag is wanted here regardless: a container gets 64 MB of shared memory and Home Assistant offers no way to raise it, so there was never anything for the test to decide.

Quoting the original test would not have been enough. With a multi-word value it then fails on a non-numeric argument and writes to stderr anyway.

## Why this reached a release

It is invisible to a build and it depends on the host. Here `findmnt` returned a single value, the test succeeded, nothing was written to stderr, and the browser started.

CI builds both architectures but never boots either, so nothing in the pipeline could have caught it. This is the third runtime defect in this application that a green build could not see.

## Rollback Plan

Revert via GitHub's Revert button. Debian's fragment takes over again and affected hosts go back to crash-looping.

## Test plan

**Verifiable by agent before merging**
- [x] Reproduced the reported failure by replacing the fragment with one whose test errors the same way — same `unexpected operator` line, same `chrome not reachable`
- [x] Restored the flag through a separate fragment and confirmed from the real Chromium command line that it was present; the browser still failed, twice, and again with no other container running
- [x] Compared the working and failing command lines and found them identical apart from a duplicated flag, ruling the flag out
- [x] Reproduced the failure on the known-good image using a fragment that only writes to stderr, isolating the output as the cause
- [x] Confirmed the wrapper now writes nothing to stderr, by discarding stdout and showing the remainder empty
- [x] Booted the built image to `Test successful!` and `Serving on http://0.0.0.0:8191`
- [x] Probed both endpoints — `GET /` returns the ready response at version 3.5.0, and `POST /v1` with `sessions.list` returns `status: ok`
- [x] Confirmed the only executable line in the shipped fragment is the export, so nothing host-dependent remains
- [x] `./.github/scripts/verify-release-wiring.sh` passes

**Cannot be verified before merge**
- [ ] That it starts on the reporter's Home Assistant OS host — requires that machine, since the trigger depends on what `findmnt` reports there
