### PR TITLE
fix: stop reporting an error when an application is stopped

### DIFF
--- a/bazarr/rootfs/etc/s6-overlay/s6-rc.d/bazarr/finish
+++ b/bazarr/rootfs/etc/s6-overlay/s6-rc.d/bazarr/finish
@@ -14,10 +14,15 @@ bashio::log.info \
   "(by signal ${exit_code_signal})"
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
+  # Home Assistant stops an application with SIGTERM, so that is a shutdown
+  # rather than a failure. Reporting one made it show as errored on every stop.
+  if [[ "${exit_code_signal}" -eq 15 ]]; then
+    exec /run/s6/basedir/bin/halt
+  fi
+
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
   fi
-  [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo "${exit_code_service}" > /run/s6-linux-init-container-results/exitcode

--- a/flaresolverr/rootfs/etc/s6-overlay/s6-rc.d/flaresolverr/finish
+++ b/flaresolverr/rootfs/etc/s6-overlay/s6-rc.d/flaresolverr/finish
@@ -14,10 +14,15 @@ bashio::log.info \
   "(by signal ${exit_code_signal})"
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
+  # Home Assistant stops an application with SIGTERM, so that is a shutdown
+  # rather than a failure. Reporting one made it show as errored on every stop.
+  if [[ "${exit_code_signal}" -eq 15 ]]; then
+    exec /run/s6/basedir/bin/halt
+  fi
+
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
   fi
-  [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo "${exit_code_service}" > /run/s6-linux-init-container-results/exitcode

--- a/notifiarr/rootfs/etc/s6-overlay/s6-rc.d/notifiarr/finish
+++ b/notifiarr/rootfs/etc/s6-overlay/s6-rc.d/notifiarr/finish
@@ -14,10 +14,15 @@ bashio::log.info \
   "(by signal ${exit_code_signal})"
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
+  # Home Assistant stops an application with SIGTERM, so that is a shutdown
+  # rather than a failure. Reporting one made it show as errored on every stop.
+  if [[ "${exit_code_signal}" -eq 15 ]]; then
+    exec /run/s6/basedir/bin/halt
+  fi
+
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
   fi
-  [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo "${exit_code_service}" > /run/s6-linux-init-container-results/exitcode

--- a/nzbget/rootfs/etc/s6-overlay/s6-rc.d/nzbget/finish
+++ b/nzbget/rootfs/etc/s6-overlay/s6-rc.d/nzbget/finish
@@ -14,10 +14,15 @@ bashio::log.info \
   "(by signal ${exit_code_signal})"
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
+  # Home Assistant stops an application with SIGTERM, so that is a shutdown
+  # rather than a failure. Reporting one made it show as errored on every stop.
+  if [[ "${exit_code_signal}" -eq 15 ]]; then
+    exec /run/s6/basedir/bin/halt
+  fi
+
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
   fi
-  [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo "${exit_code_service}" > /run/s6-linux-init-container-results/exitcode

--- a/prowlarr/rootfs/etc/s6-overlay/s6-rc.d/prowlarr/finish
+++ b/prowlarr/rootfs/etc/s6-overlay/s6-rc.d/prowlarr/finish
@@ -14,10 +14,15 @@ bashio::log.info \
   "(by signal ${exit_code_signal})"
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
+  # Home Assistant stops an application with SIGTERM, so that is a shutdown
+  # rather than a failure. Reporting one made it show as errored on every stop.
+  if [[ "${exit_code_signal}" -eq 15 ]]; then
+    exec /run/s6/basedir/bin/halt
+  fi
+
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
   fi
-  [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo "${exit_code_service}" > /run/s6-linux-init-container-results/exitcode

--- a/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/qbittorrent/finish
+++ b/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/qbittorrent/finish
@@ -14,10 +14,15 @@ bashio::log.info \
   "(by signal ${exit_code_signal})"
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
+  # Home Assistant stops an application with SIGTERM, so that is a shutdown
+  # rather than a failure. Reporting one made it show as errored on every stop.
+  if [[ "${exit_code_signal}" -eq 15 ]]; then
+    exec /run/s6/basedir/bin/halt
+  fi
+
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
   fi
-  [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo "${exit_code_service}" > /run/s6-linux-init-container-results/exitcode

--- a/radarr/rootfs/etc/s6-overlay/s6-rc.d/radarr/finish
+++ b/radarr/rootfs/etc/s6-overlay/s6-rc.d/radarr/finish
@@ -14,10 +14,15 @@ bashio::log.info \
   "(by signal ${exit_code_signal})"
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
+  # Home Assistant stops an application with SIGTERM, so that is a shutdown
+  # rather than a failure. Reporting one made it show as errored on every stop.
+  if [[ "${exit_code_signal}" -eq 15 ]]; then
+    exec /run/s6/basedir/bin/halt
+  fi
+
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
   fi
-  [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo "${exit_code_service}" > /run/s6-linux-init-container-results/exitcode

--- a/seerr/rootfs/etc/s6-overlay/s6-rc.d/seerr/finish
+++ b/seerr/rootfs/etc/s6-overlay/s6-rc.d/seerr/finish
@@ -14,10 +14,15 @@ bashio::log.info \
   "(by signal ${exit_code_signal})"
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
+  # Home Assistant stops an application with SIGTERM, so that is a shutdown
+  # rather than a failure. Reporting one made it show as errored on every stop.
+  if [[ "${exit_code_signal}" -eq 15 ]]; then
+    exec /run/s6/basedir/bin/halt
+  fi
+
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
   fi
-  [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo "${exit_code_service}" > /run/s6-linux-init-container-results/exitcode

--- a/sonarr/rootfs/etc/s6-overlay/s6-rc.d/sonarr/finish
+++ b/sonarr/rootfs/etc/s6-overlay/s6-rc.d/sonarr/finish
@@ -14,10 +14,15 @@ bashio::log.info \
   "(by signal ${exit_code_signal})"
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
+  # Home Assistant stops an application with SIGTERM, so that is a shutdown
+  # rather than a failure. Reporting one made it show as errored on every stop.
+  if [[ "${exit_code_signal}" -eq 15 ]]; then
+    exec /run/s6/basedir/bin/halt
+  fi
+
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
   fi
-  [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo "${exit_code_service}" > /run/s6-linux-init-container-results/exitcode

--- a/unpackerr/rootfs/etc/s6-overlay/s6-rc.d/unpackerr/finish
+++ b/unpackerr/rootfs/etc/s6-overlay/s6-rc.d/unpackerr/finish
@@ -14,10 +14,15 @@ bashio::log.info \
   "(by signal ${exit_code_signal})"
 
 if [[ "${exit_code_service}" -eq 256 ]]; then
+  # Home Assistant stops an application with SIGTERM, so that is a shutdown
+  # rather than a failure. Reporting one made it show as errored on every stop.
+  if [[ "${exit_code_signal}" -eq 15 ]]; then
+    exec /run/s6/basedir/bin/halt
+  fi
+
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo $((128 + $exit_code_signal)) > /run/s6-linux-init-container-results/exitcode
   fi
-  [[ "${exit_code_signal}" -eq 15 ]] && exec /run/s6/basedir/bin/halt
 elif [[ "${exit_code_service}" -ne 0 ]]; then
   if [[ "${exit_code_container}" -eq 0 ]]; then
     echo "${exit_code_service}" > /run/s6-linux-init-container-results/exitcode


### PR DESCRIPTION
## Summary

Fixes Home Assistant showing an application as failed every time it is stopped, caused by the service teardown reporting the stop signal as the container's exit status, by exiting cleanly when the stop was deliberate.

Before this change, stopping an application left its container reporting exit code 143. It now reports 0, and an application that fails on its own still reports its own code.

## Problem

Stopping an application makes Home Assistant show it as errored, so a routine stop is indistinguishable from a crash at a glance.

Home Assistant stops an application by sending SIGTERM. When the process is killed by a signal rather than exiting on its own, s6 hands the teardown script 256 along with the signal number, and the script turned that pair into `128 + 15` and wrote it as the container's exit status.

**Whether it happens depends on the application, not the packaging.** That is what made it look arbitrary:

- **Unpackerr** handles SIGTERM itself and exits 0, so the teardown sees a clean exit and writes nothing.
- **FlareSolverr** does not, so s6 kills it, and the teardown reported a failure.

Both were checked by building and stopping them rather than reasoned about.

## Evidence

The same image, stopped the same way, before and after:

| Scenario | Container exit code | Log line |
|---|---|---|
| Stopped, before | **143** | `exited with code 256 (by signal 15)` |
| Stopped, after | **0** | `exited with code 256 (by signal 15)` |
| Service exits 1 on its own | **1** | `exited with code 1 (by signal 0)` |

The third row is the one that matters for review. A genuine failure still halts the container and still reports its own code, so this does not buy a clean stop by hiding crashes.

## Solution

The teardown now returns for SIGTERM before anything writes an exit status, so a deliberate stop ends at 0.

Nothing else moves. Any other signal still reports `128 + signal`, and an application that exits non-zero on its own still halts the container carrying that code.

**n8n is deliberately untouched.** Its service predates this layout and uses the older `services.d` shape, which already ignores a signalled exit, so it never had the problem. That was confirmed by reading it rather than assumed from its age.

## Review Guide

No call-flow tree applies — the same teardown script in ten applications, each differing only by the name it logs.

- **Any one of the ten `finish` scripts** — they are identical in logic, so reviewing one reviews all ten. The ordering is what makes the fix work: the SIGTERM branch has to sit before the line that writes an exit status, and it does in all ten (line 19 against line 24 in each).

## Release impact

This releases ten applications and writes an entry into ten changelogs.

That is the point rather than a side effect. A release is what carries a change to an installed instance, so fixing fewer would leave the rest reporting a false failure on every stop.

It is a deliberate exception to the repository's one-application-per-pull-request rule, which exists to keep changelogs readable rather than to prevent a genuinely repository-wide fix.

## Rollback Plan

Revert via GitHub's Revert button. Stopping an application goes back to reporting exit code 143, and Home Assistant goes back to showing it as errored.

## Test plan

**Verifiable by agent before merging**
- [x] Reproduced the failure: built FlareSolverr unchanged, started it, stopped it, and the container reported exit code 143
- [x] Confirmed the fix from the same build stopped the same way — exit code 0
- [x] Confirmed a genuine failure still reports one, using a variant whose service exits 1 — container exit code 1
- [x] Confirmed Unpackerr was never affected, by building and stopping it and seeing the teardown report a clean exit it handled itself
- [x] `bash -n` passes on all ten scripts
- [x] Confirmed in all ten that the SIGTERM branch precedes the line writing an exit status, so the fix is not correct only in the one that was tested
- [x] `./.github/scripts/verify-release-wiring.sh` passes

**Cannot be verified before merge**
- [ ] That Home Assistant stops showing the application as errored — requires an installed Supervisor instance, since that is Supervisor reacting to the container's exit status rather than anything observable inside the container

## Follow-up

The log line still reads `exited with code 256 (by signal 15)` after a stop, because only the reported status changed. Rewording it so a deliberate stop does not read like a crash is a small separate change, worth doing if the message is what draws the eye.
