### PR TITLE
ci: scope the build cache to each application

### DIFF
--- a/.github/workflows/_build-application.yaml
+++ b/.github/workflows/_build-application.yaml
@@ -79,6 +79,7 @@ jobs:
         uses: home-assistant/builder/actions/build-image@2026.06.0
         with:
           arch: ${{ matrix.arch }}
+          cache-gha-scope: ${{ inputs.app }}
           container-registry-password: ${{ secrets.GITHUB_TOKEN }}
           context: './${{ inputs.app }}'
           cosign: ${{ inputs.publish }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,14 @@ amd64 on a native runner.
 **A green build is not a working application.** Radarr, Sonarr and Prowlarr all
 built cleanly while failing to start. Boot the container and probe the port.
 
+**The build cache is scoped per application on purpose.** `build-image` scopes
+its GitHub Actions cache to the architecture alone unless told otherwise, so a
+repository building more than one image has every application writing `mode=max`
+into the same two scopes and evicting whatever built last. Nothing fails, the
+builds are just slower than they look. `cache-gha-scope` is set to the
+application in `_build-application.yaml`, and removing it puts the eleven
+applications back to sharing two scopes.
+
 **`UpdateMethod=docker` disables the application's own updater.** These images
 write it into `/opt/package_info` deliberately. The application will show that a
 newer version exists and refuse to install it, which is why the packaging is the


### PR DESCRIPTION
## Summary

Stops every application sharing one build cache, caused by the build action scoping its cache to the architecture alone unless told otherwise, by naming the application in that scope.

Before this change the eleven applications wrote into two scopes between them, so each build overwrote whatever built before it and then missed on its own layers. They now have one scope each.

Caching was already switched on, and nothing was failing — the builds were slower than they looked.

## Problem

Every application's build discards the cache of the one before it.

The build action enables GitHub Actions caching by default, so the cache existed. It just had nowhere useful to live: with no scope given, the scope is the architecture, so all eleven applications write `mode=max` into `amd64` and `aarch64` and nothing else.

Each build therefore evicts the previous application's entry, then looks for its own layers and finds another application's. The shared cache budget churns for no benefit.

Nothing reports this. There is no error and no warning — only build times that look normal because they have always been that way.

## Evidence

The action composes the scope like this, at the pinned version:

```sh
if [[ -z "${CACHE_SCOPE}" ]]; then
  cache_scope="${ARCH}"
else
  cache_scope="${ARCH}-${CACHE_SCOPE}"
fi
cache_to+=("type=gha,mode=max,scope=${cache_scope}")
```

Replaying that over the eleven applications and two architectures:

| | Distinct scopes | Shape |
|---|---|---|
| Before | **2** | eleven applications share `aarch64`, eleven share `amd64` |
| After | **22** | `aarch64-bazarr` … `amd64-unpackerr`, one each |

The action's own input describes this exact situation. Its description says the scope defaults to the architecture and should be set "if building multiple images from a single repo", so this was a misconfiguration rather than a missing capability.

## Solution

The build step now names the application in its cache scope, which is the input the action provides for repositories holding more than one image.

Nothing else moves. GitHub Actions caching was already on, so this does not enable it, and the registry cache that reads the image's `latest` tag is untouched.

No image content changes either — only what BuildKit is permitted to reuse.

AGENTS.md gains a Traps entry, because a silent misconfiguration is the kind that returns. Dropping the input puts the applications straight back to sharing two scopes, with nothing to say so.

## Review Guide

- **`.github/workflows/_build-application.yaml`** — one input on the build step. Worth confirming it reads `${{ inputs.app }}` and not the matrix architecture, since the action already appends the architecture itself and duplicating it would defeat the separation.

## Rollback Plan

Revert via GitHub's Revert button. The applications go back to sharing two cache scopes, and builds go back to their current speed.

## Test plan

**Verifiable by agent before merging**
- [x] Workflow YAML parses, with the new input present on the build step alongside its other ten
- [x] Replayed the action's scope logic across all eleven applications and both architectures — two shared scopes become twenty-two distinct ones, as tabled above
- [x] `prettier --check` passes on both changed files
- [x] The build jobs on this pull request compose the scope per application, confirmed from their own logs: FlareSolverr's amd64 job caches to `scope=amd64-flaresolverr`, and Seerr's aarch64 job reads and writes `scope=aarch64-seerr`. No job uses a bare architecture

**Cannot be verified before merge**
- [ ] An actual cache hit — that needs two consecutive builds of the same application against the same scope, and the first run after this lands can only populate the new scopes

## What to expect

The first build of each application after this merges cannot hit the new scopes, because nothing has written to them yet. The gain starts from the run after that.

It should show up most on the applications that do real work in their layers. n8n installs a toolchain and compiles through npm, while Seerr and FlareSolverr pull large upstream images.
