### PR TITLE
ci: stop release pull requests stranding each other

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  cancel-in-progress: false
+  group: release-please
+
 permissions:
   contents: read
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,7 +234,7 @@ flowchart TD
     A[Renovate finds a newer application version] --> B[PR bumping ARG in the Dockerfile]
     B --> C{Merged to main?}
     C -- no --> D([Nothing released])
-    C -- yes --> E[release-please opens a release PR]
+    C -- yes --> E[release-please opens the release PR]
     E --> F[Bumps config.yaml version, writes the CHANGELOG]
     F --> G{Release PR merged?}
     G -- no --> D
@@ -244,6 +244,12 @@ flowchart TD
 
 Each application is its own release-please package. A commit is attributed to
 one by the files it touches, so a change under `radarr/` releases Radarr alone.
+
+**There is one release pull request, not one per application.** Each application
+still gets its own version, tag and changelog inside it; what is shared is the
+pull request carrying them. `separate-pull-requests` was `true` until several
+applications first became releasable at once, and the reason it cannot go back
+is in Traps.
 
 **Two annotations hold this together, and removing either fails silently.**
 
@@ -269,6 +275,40 @@ different SHAs and identical text. That is not hypothetical: it produced 10
 duplicated pairs across four open release pull requests before merge commits
 were turned off. Squashing writes one commit, and rebasing adds no merge commit
 to double-count, so both remaining strategies are safe.
+
+**A stale release pull request cannot merge, and release-please will not refresh
+it.** release-please rewrites a release pull request only when the release it
+computes changes. One whose release is unchanged keeps its original base for
+good, so everything merged to main since then leaves it behind.
+`.release-please-manifest.json` is enough to make that fatal on its own: its
+keys are one per application in alphabetical order, so releasing an
+application's alphabetical neighbour is an adjacent-line change and git refuses
+to merge it. Releasing qbittorrent and seerr is what stranded Radarr.
+
+`separate-pull-requests: false` is what keeps it from recurring. One release
+pull request at a time means nothing can land a competing manifest edit while it
+is open, so the neighbours it would have collided with no longer exist. The cost
+is that releases batch: you cannot hold one application back while shipping
+another.
+
+**Setting `separate-pull-requests` back to `true` brings the conflicts back the
+same day**, and the flag alone will not fix them. What that needs is a workflow
+step merging main into each open release pull request after every run and
+resolving the manifest itself: take main's copy and overlay the keys the pull
+request changed against its own merge base. That is always correct, because a
+release pull request only ever moves the versions it is releasing. Conflicts
+anywhere else are not worth guessing at and should be left to a human.
+
+What remains is narrow enough to fix by hand. It needs a commit that both
+changes no computed release, so `chore`, `docs`, `ci` or `refactor`, and touches
+a line next to one the open release pull request is editing. Registering a new
+application under a non-releasing type is the realistic way in.
+
+**Concurrent release-please runs race each other.** Every release merge pushes
+main and every push starts a run. Five auto-merges landing inside a minute
+started five overlapping runs that tried to cut the same tags and strip the same
+labels; one died on `Label does not exist`. The workflow has a `concurrency`
+group now. Do not add `cancel-in-progress` — the last push must still get a run.
 
 **Nothing enforces any of this.** There is no commitlint in this repository — no
 configuration, no dependency, no hook — and `.github/workflows/lint.yaml` runs

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -47,5 +47,5 @@
     }
   },
   "release-type": "simple",
-  "separate-pull-requests": true
+  "separate-pull-requests": false
 }


### PR DESCRIPTION
## Summary

Fixes six release pull requests that cannot merge — [#98](https://github.com/kanso-labs/home-assistant-applications/pull/98), [#101](https://github.com/kanso-labs/home-assistant-applications/pull/101), [#102](https://github.com/kanso-labs/home-assistant-applications/pull/102), [#103](https://github.com/kanso-labs/home-assistant-applications/pull/103), [#104](https://github.com/kanso-labs/home-assistant-applications/pull/104) and [#107](https://github.com/kanso-labs/home-assistant-applications/pull/107) — caused by sibling releases editing alphabetically adjacent lines of the shared `.release-please-manifest.json`, by collapsing them into one release pull request so no sibling exists to collide with.

Before this change each application opened its own release pull request, and releasing one application's alphabetical neighbour left the others unmergeable for good. release-please now opens a single release pull request carrying every application ready to ship.

This removes the situation that triggers the failure rather than the failure itself. release-please's own behaviour is untouched, and the narrow case that survives is recorded in `AGENTS.md` and in Design Decisions below.

## Problem

Six release pull requests are open and every one of them reports `CONFLICTING`. No application can ship until they are dealt with by hand, which for a repository whose whole update path runs through release-please means Home Assistant is offered nothing.

The shared manifest is the entire conflict surface. Its keys are one per application in alphabetical order, so releasing radarr's neighbours — qbittorrent and seerr, both merged within seconds of each other — puts a changed hunk on each side of radarr's own line. `CHANGELOG.md` and `config.yaml` are per-application and never collide.

Nothing recovers from that on its own, because release-please rewrites a release pull request only when the release it computes changes. Radarr's computed release did not change, so five subsequent runs left the pull request on its original base. [#104](https://github.com/kanso-labs/home-assistant-applications/pull/104) still reports `updatedAt` of `13:48:03` and a merge base of `68291d3`.

A second fault shares the trigger. Five auto-merges landing inside 46 seconds started five overlapping workflow runs with no `concurrency` group, and they raced each other to cut the same tags and strip the same labels.

## Evidence

`git merge-tree` against [#104](https://github.com/kanso-labs/home-assistant-applications/pull/104) reproduces the conflict, and reports `.release-please-manifest.json` as the only conflicting file:

```
changed in both
  base   100644 c1f4238 .release-please-manifest.json
  our    100644 a61b03b .release-please-manifest.json
  their  100644 296091a .release-please-manifest.json
@@ -5,9 +5,15 @@
   "prowlarr": "1.1.0",
+<<<<<<< .our
   "qbittorrent": "1.1.1",
   "radarr": "1.1.0",
   "seerr": "1.1.1",
+=======
+  "qbittorrent": "1.1.0",
+  "radarr": "1.1.1",
```

The concurrency fault is visible in [run 31707056563](https://github.com/kanso-labs/home-assistant-applications/actions/runs/31707056563), which failed outright after a competing run had already removed the label it was reaching for:

```
⚠ Duplicate release tag: seerr-v1.1.1
❯ removing labels: autorelease: pending from issue/pull 99
⚠ Duplicate release tag: qbittorrent-v1.1.1
⚠ Duplicate release tag: unpackerr-v1.1.1
##[error]release-please failed: Label does not exist
```

## Solution

Two independent changes, one per fault.

**`separate-pull-requests: false` in `release-please-config.json`.** One release pull request at a time means nothing can land a competing manifest edit while one is open, so the neighbours that collided no longer exist. Each application still gets its own version, tag and changelog inside that pull request, and `build.yaml` is path-filtered so it still builds only the applications that changed.

**A `concurrency` group on the release workflow.** Runs now queue instead of racing. `cancel-in-progress` is deliberately absent, because the last push to `main` must still produce a run.

`AGENTS.md` gains both as Traps entries, alongside the tradeoff below.

## Design Decisions

| Decision | Context |
|---|---|
| Accept batched releases rather than keep per-application release pull requests | Collapsing to one pull request means you can no longer hold one application back while shipping another. Keeping them separate would need machinery to repair the conflicts instead of preventing them, and prevention is the smaller surface. |
| Drop the workflow step that merged `main` into open release pull requests | It was written and verified against [#104](https://github.com/kanso-labs/home-assistant-applications/pull/104), then dropped: with one release pull request the collision it repaired cannot occur, so it was ~50 lines of untested-in-CI code pushing to branches with an application token, guarding nothing. `AGENTS.md` records the approach for whoever reverts `separate-pull-requests`. |

The residual risk after this is narrow enough to merge by hand. It needs a commit that both changes no computed release, so `chore`, `docs`, `ci` or `refactor`, and touches a line next to one the open release pull request is editing. Registering a new application under a non-releasing type is the realistic way in.

## Rollback Plan

Revert this pull request via GitHub's Revert button. Nothing here writes state — no tags, no releases, no published images — so a revert restores the previous behaviour on the next push to `main`. Any release pull request open at the time should be closed rather than merged, since release-please will recompute it under whichever model is active.

## Test plan

**Verifiable by agent before merging**

- [x] Reproduced the conflict with `git merge-tree` against [#104](https://github.com/kanso-labs/home-assistant-applications/pull/104), confirming the manifest is the only conflicting file
- [x] Confirmed the stale-base claim from the GitHub API: five runs after the neighbouring releases merged, [#104](https://github.com/kanso-labs/home-assistant-applications/pull/104) was still on merge base `68291d3`
- [x] Dry-ran the manifest resolution described in Design Decisions against [#104](https://github.com/kanso-labs/home-assistant-applications/pull/104) in a throwaway worktree — it hit the conflict, resolved it, and the branch then diffed against `main` as exactly the intended radarr release and nothing else
- [x] Workflow YAML parses, with the `concurrency` block and step order as intended

**Cannot be verified before merge**

- [ ] A live run of the release workflow — it triggers only on `push` to `main` and carries no dispatch trigger, so the first real execution is this merge. The change is four lines of workflow configuration with no script logic.
- [ ] Confirm release-please opens one combined release pull request — depends on the six stale ones being closed after this lands

## After merging

The six open release pull requests are artefacts of the old model and should be closed with their branches deleted, rather than merged. release-please recomputes every pending release from the component tags, so closing them loses nothing: radarr's last tag is `radarr-v1.1.0` and `68291d3` is still unreleased for it, so it comes back as 1.1.1 inside the new combined pull request.
