### PR TITLE
ci: name the combined release pull request

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,6 +251,12 @@ pull request carrying them. `separate-pull-requests` was `true` until several
 applications first became releasable at once, and the reason it cannot go back
 is in Traps.
 
+Its title comes from `group-pull-request-title-pattern`, because the default
+names the target branch and reads `chore: release main`. Whatever it is changed
+to has to stay a type that releases nothing: the squash makes that title the
+only commit on `main`, so `feat` or `fix` there would release every application
+a second time.
+
 **Two annotations hold this together, and removing either fails silently.**
 
 - `# x-release-please-version` beside `version` in `config.yaml` tells

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "group-pull-request-title-pattern": "chore: release applications",
   "packages": {
     "bazarr": {
       "component": "bazarr",


### PR DESCRIPTION
## Summary

Renames the combined release pull request from `chore: release main` to `chore: release applications`, caused by release-please's default group title pattern naming the target branch, by setting `group-pull-request-title-pattern` explicitly.

The title used to end in the branch it targets. Since releases only ever run from `main`, that was the one variable part of the title and it carried no information.

## Problem

[#110](https://github.com/kanso-labs/home-assistant-applications/pull/110) is the first combined release pull request, opened after [#109](https://github.com/kanso-labs/home-assistant-applications/pull/109) collapsed the per-application ones into a single pull request. It is titled `chore: release main`.

That title becomes the only commit on `main` once it squashes, so it is what anyone reads when scanning history for when a release landed. `main` names the branch every release already targets, so the title says nothing the reader did not know.

## Solution

`group-pull-request-title-pattern` now sets the title to `chore: release applications`, replacing release-please's default of `chore${scope}: release ${branch}`. The pattern is a fixed string with no placeholders, so nothing can render as an empty or literal `${…}` fragment.

`AGENTS.md` records why the option is set, and the constraint on changing it: the title has to stay a type that releases nothing, because the squash turns it into a commit on `main` and `feat` or `fix` there would release every application a second time.

## Test plan

**Verifiable by agent before merging**

- [x] Confirmed `group-pull-request-title-pattern` is a real top-level option, against the schema `release-please-config.json` already declares in `$schema`
- [x] `release-please-config.json` parses, with keys still in alphabetical order
- [x] `./.github/scripts/verify-release-wiring.sh` passes, so the packages and manifest entries are untouched by the new key
- [x] `npx prettier --check` passes on both files

**Cannot be verified before merge**

- [ ] Confirm the next combined release pull request opens as `chore: release applications` — the title is only produced by a release-please run, which triggers on `push` to `main`

## After merging

[#110](https://github.com/kanso-labs/home-assistant-applications/pull/110) was opened under the old pattern and keeps its title. Either edit that one title by hand before merging it, or close it and let the next run reopen it under the new pattern — release-please recomputes the pending releases from the component tags either way.
