### PR TITLE
ci: call the shared release-please workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -5,54 +5,32 @@ on:
     branches:
       - main
 
+# Every release merge pushes main, and every push starts a run. Five auto-merges
+# landing inside a minute started five overlapping runs that tried to cut the
+# same tags and strip the same labels, and one died on "Label does not exist".
+# Do not add cancel-in-progress: the last push must still get a run, or the
+# release it carries is never proposed.
+#
+# This stays in the caller rather than moving into the shared workflow. GitHub
+# documents concurrency at the caller and says nothing either way about a group
+# declared in a called workflow, and this guard only matters during exactly the
+# race above — the worst kind of thing to rest on undocumented behaviour.
 concurrency:
   cancel-in-progress: false
   group: release-please
 
+# The application token below does the writing, so GITHUB_TOKEN stays on read.
 permissions:
   contents: read
 
 jobs:
+  # Everything this used to do inline — minting the token, proposing the
+  # releases, enabling auto-merge — now lives in the shared workflow, which the
+  # other kanso-labs repositories call as well. What is left here is the part
+  # that is genuinely this repository's: its concurrency group and its secrets.
   release-please:
     name: Propose releases
-    runs-on: ubuntu-latest
-    steps:
-      # Pull requests opened with the default GITHUB_TOKEN do not start
-      # workflow runs. Their checks sit at action_required until somebody
-      # approves them by hand, so a release stalls until then. Requests made
-      # with an application token trigger the checks like any other.
-      - name: Mint an application token
-        id: token
-        uses: actions/create-github-app-token@v3.2.0
-        with:
-          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
-
-      - name: Propose releases
-        id: release
-        uses: googleapis/release-please-action@v5.0.0
-        with:
-          token: ${{ steps.token.outputs.token }}
-
-      # Auto-merge only queues when something is already blocking the pull
-      # request, which here is the ruleset requiring the two Confirm checks.
-      # Remove that rule and this stops waiting for anything: --auto on an
-      # unblocked pull request merges it on the spot.
-      #
-      # Failing to enable it is not worth failing the run over. The release
-      # pull request itself is already open and correct, and merging it by hand
-      # still works, so this warns and moves on.
-      - name: Enable auto-merge on the release pull requests
-        if: steps.release.outputs.prs != '' && steps.release.outputs.prs != '[]'
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-          GH_REPO: ${{ github.repository }}
-          PRS: ${{ steps.release.outputs.prs }}
-        run: |
-          jq -r '.[].number' <<< "${PRS}" | while read -r pr; do
-            if gh pr merge --auto --squash "${pr}"; then
-              echo "Auto-merge enabled on #${pr}."
-            else
-              echo "::warning::Could not enable auto-merge on #${pr}. Merge it by hand."
-            fi
-          done
+    uses: kanso-labs/github-actions/.github/workflows/_release-please.yaml@v1.0.2
+    secrets:
+      app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+      private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,14 @@ If it never moves, nothing you change inside an image ever reaches anyone.
 
 Nobody edits that field by hand. release-please owns it.
 
+How it runs is shared with the other `kanso-labs` repositories rather than
+configured here:
+[`kanso-labs/github-actions`](https://github.com/kanso-labs/github-actions)
+holds the workflow, and `.github/workflows/release-please.yaml` calls it at a
+pinned tag. Changing the token, the auto-merge behaviour, or the release-please
+version means changing it there and bumping the pin here, which Renovate opens a
+pull request for.
+
 ```mermaid
 flowchart TD
     A[Renovate finds a newer application version] --> B[PR bumping ARG in the Dockerfile]
@@ -315,6 +323,12 @@ main and every push starts a run. Five auto-merges landing inside a minute
 started five overlapping runs that tried to cut the same tags and strip the same
 labels; one died on `Label does not exist`. The workflow has a `concurrency`
 group now. Do not add `cancel-in-progress` — the last push must still get a run.
+
+That group has to stay in `release-please.yaml` here, even though the rest of
+that workflow moved out. GitHub documents `concurrency` at the caller and says
+nothing either way about a group declared inside a called workflow, so keeping
+it here is the difference between a guard that is known to work and one that
+might quietly be doing nothing until the race above happens again.
 
 **Nothing enforces any of this.** There is no commitlint in this repository — no
 configuration, no dependency, no hook — and `.github/workflows/lint.yaml` runs


### PR DESCRIPTION

## Summary

Moves this repository's release-please job into a shared reusable workflow at
[kanso-labs/github-actions](https://github.com/kanso-labs/github-actions), so
that the app-token handling it had all along becomes available to the sibling
repositories that need it, by replacing the inline job with a call pinned at
[v1.0.2](https://github.com/kanso-labs/github-actions/releases/tag/v1.0.2).

Behaviour here does not change. The same action runs at the same version with
the same app token, and auto-merge is still enabled on the release pull
requests.

## Problem

Minting the GitHub App token, proposing the releases, and enabling auto-merge on
the release pull request were configured in this repository and nowhere else.

[kanso-ui](https://github.com/kanso-labs/kanso-ui) and
[unplugin-style-dictionary](https://github.com/kanso-labs/unplugin-style-dictionary)
both still run release-please on a bare `GITHUB_TOKEN`. A pull request opened
with that token starts no workflow runs, so their release pull requests never
start the `Build`, `Lint` and `Test` checks their own rulesets require in order
to merge. Those releases can only land by bypassing the ruleset.

Nothing in this workflow was ever specific to this repository except its secrets
and its concurrency group.

## Solution

The body of the job now lives in `github-actions` as `_release-please.yaml`, and
this repository calls it at a pinned tag. The inline steps are gone; what
remains is the trigger, the concurrency group, the permissions, and the two
secrets.

Two things stay behind deliberately, and both would be wrong to tidy away later.

**The concurrency group stays in this file.** GitHub documents `concurrency` at
the caller and says nothing either way about a group declared inside a called
workflow. This guard only matters during the exact race that already happened
here once — five auto-merges inside a minute, five overlapping runs, one dying
on `Label does not exist` — which makes it the worst possible thing to rest on
undocumented behaviour. At the caller it is known to work and visible in review.

**`permissions: contents: read` stays as it is.** The shared workflow declares
no `permissions` block at all, precisely so this repository can keep its tighter
grant. A called workflow cannot request more than its caller granted, so a write
block in the shared file would have forced this repository to widen a token that
does no writing.

`AGENTS.md` records both, next to the incident that motivates the first.

## Review Guide

**Focus areas**

- **`.github/workflows/release-please.yaml`** — worth reading as a whole rather
  than as a diff. The question it has to answer is whether anything the inline
  steps did is now missing, rather than merely relocated.

## Test plan

**Verifiable by agent before merging**

- [x] The shared workflow is canaried end to end in `github-actions`, which
      calls it exactly the way this repository does.
      [Run 31724069058](https://github.com/kanso-labs/github-actions/actions/runs/31724069058)
      resolved `_release-please.yaml@refs/tags/v1.0.0`, took the no-app-token
      path, and ran release-please against the repository's real config.
- [x] [Run 31724550099](https://github.com/kanso-labs/github-actions/actions/runs/31724550099)
      opened a release pull request, enabled auto-merge on it, and set the
      passthrough outputs.
- [x] Releases
      [v1.0.1](https://github.com/kanso-labs/github-actions/releases/tag/v1.0.1)
      and
      [v1.0.2](https://github.com/kanso-labs/github-actions/releases/tag/v1.0.2)
      were both cut through this workflow.
- [x] The canary found a real defect, fixed in v1.0.2, which is the version
      pinned here. Auto-merging a release pull request with `GITHUB_TOKEN`
      leaves the release half-applied: the merge push starts no run, so nothing
      cuts the tag until some later unrelated push does. Auto-merge is now gated
      on an app token being supplied. This repository supplies one and is
      unaffected either way.
- [x] `actionlint` clean on the changed workflow; `prettier --check` clean.

**Cannot be verified before merge**

- [ ] A run of this repository's own `release-please.yaml` — it does nothing
      except on a push to `main`, which no pull request reproduces. The shared
      workflow itself was proven end to end by the canary above, so what is
      unproven here is only this file's caller-side wiring, which is four lines
      and statically checked. The first push after merge is the real proof.

## Rollback Plan

Revert this PR via GitHub's Revert button. It restores the inline job verbatim,
and nothing outside this repository depends on the call existing.
