### PR TITLE
ci: authenticate with the client id

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -30,7 +30,7 @@ jobs:
   # that is genuinely this repository's: its concurrency group and its secrets.
   release-please:
     name: Propose releases
-    uses: kanso-labs/github-actions/.github/workflows/_release-please.yaml@v1.2.1
+    uses: kanso-labs/github-actions/.github/workflows/_release-please.yaml@v1.3.0
     secrets:
-      app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+      client-id: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
       private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}


### PR DESCRIPTION

## Summary

Renames the credential this repository passes to the shared release workflow
from the deprecated `app-id` to `client-id`, so that the next major of that
workflow — which removes `app-id` entirely — arrives here as a pin bump and
nothing else.

Before this change `release-please.yaml` passed `app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}`. It now
passes `client-id: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}`, and the pin moves from the
tag it was on to `v1.3.0`.

Behaviour is unchanged. The same GitHub App mints the same token.

## Problem

`app-id` is a deprecated alias in
[`kanso-labs/github-actions`](https://github.com/kanso-labs/github-actions), kept
only so callers passing it kept working while they migrated.
[github-actions#16](https://github.com/kanso-labs/github-actions/pull/16) removes
it and cuts v2.0.0.

Nothing is on fire: this repository pins an exact v1 tag, and a major is the one
update type Renovate does not automerge here, so v2 cannot arrive unannounced.
But left alone, the eventual bump would be a pin change *and* a rename landing
together — with the failure showing up as a token that never mints, on a push to
`main`, where no pull request would have caught it.

This repository releases eleven applications, so it is also the one where a broken release run is most visible.

## Solution

The secret input is renamed and the pin moves to `v1.3.0`, the first release that
accepts `client-id`.

The value behind the secret does not need to change, which is what makes this
safe to do independently of the shared workflow's release: a GitHub App id and a
client id are both accepted as the JWT issuer, so the credential works under
either name. The rename can therefore land before v2 exists, and does.

## Test plan

**Verifiable by agent before merging**

- [x] `actionlint` clean.
- [x] No `app-id` or `APP_ID` reference remains anywhere in the repository,
      confirmed by `git grep -iE 'app-id|APP_ID'`.
- [x] `v1.3.0` genuinely accepts `client-id` — checked against the tag itself,
      whose `secrets:` block lists `app-id`, `client-id` and `private-key`,
      where `v1.2.1` listed only `app-id` and `private-key`.
- [x] `RELEASE_PLEASE_CLIENT_ID` is visible to this repository as an organization
      secret, checked through `/actions/organization-secrets`.

**Cannot be verified before merge**

- [ ] The token actually minting under the new input name — the workflow only
      runs on a push to the default branch, which no pull request reproduces.
      The first run after merge is the proof: `Mint an application token` should
      succeed and the no-credential warning should stay skipped.

## Rollback Plan

Revert through GitHub's Revert button. The previous tag still accepts `app-id`,
so the reverted state is a working configuration rather than a broken one.
