### PR TITLE
ci: restore the release pull request title pattern

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,11 +259,9 @@ pull request carrying them. `separate-pull-requests` was `true` until several
 applications first became releasable at once, and the reason it cannot go back
 is in Traps.
 
-Its title comes from `group-pull-request-title-pattern`, because the default
-names the target branch and reads `chore: release main`. Whatever it is changed
-to has to stay a type that releases nothing: the squash makes that title the
-only commit on `main`, so `feat` or `fix` there would release every application
-a second time.
+Its title reads `chore: release main`, which names the branch every release
+already targets and so says nothing. Leave it alone anyway; the reason is in
+Traps.
 
 **Two annotations hold this together, and removing either fails silently.**
 
@@ -317,6 +315,27 @@ What remains is narrow enough to fix by hand. It needs a commit that both
 changes no computed release, so `chore`, `docs`, `ci` or `refactor`, and touches
 a line next to one the open release pull request is editing. Registering a new
 application under a non-releasing type is the realistic way in.
+
+**The release pull request title is parsed back, so it cannot be a fixed
+string.** release-please reads the merged pull request's title to work out what
+to tag. `generateMatchPattern` compiles the configured pattern straight into a
+regex, turning each `${…}` into a named capture group — `${version}` becomes
+`v?(?<version>[0-9].*)`. A pattern carrying no placeholders compiles to a regex
+with no groups, the parse returns nothing, and release-please logs
+`Bad pull request title` and creates no release.
+
+Nothing recovers on its own from there. The merged pull request keeps its
+`autorelease: pending` label, and every later run stops at
+`There are untagged, merged release PRs outstanding - aborting`, so no
+application can be released until the title parses again.
+
+Setting `group-pull-request-title-pattern` to `chore: release applications` is
+what did that, to make the title say something more than the branch name. It
+cost n8n 1.1.1 its tag and blocked the queue until the pattern was reverted and
+the merged pull request retitled by hand. If a better title is wanted, the
+pattern has to keep `${version}`, and the way to check is
+`src/util/pull-request-title.ts` in the release-please version the workflow pins
+— not the schema, which accepts any string.
 
 **Concurrent release-please runs race each other.** Every release merge pushes
 main and every push starts a run. Five auto-merges landing inside a minute

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "group-pull-request-title-pattern": "chore: release applications",
   "packages": {
     "bazarr": {
       "component": "bazarr",


### PR DESCRIPTION
## Summary

Fixes the release queue being stuck, with n8n 1.1.1 merged but never tagged, caused by [#111](https://github.com/kanso-labs/home-assistant-applications/pull/111) setting a release pull request title that release-please cannot parse back, by restoring the default pattern.

Before [#111](https://github.com/kanso-labs/home-assistant-applications/pull/111) the combined release pull request was titled `chore: release main`, and release-please read that title on merge to work out what to tag. It was changed to the fixed string `chore: release applications`, which nothing can parse, so no release has been cut since.

## Problem

[#116](https://github.com/kanso-labs/home-assistant-applications/pull/116) merged on 2026-08-14 and bumped n8n to 1.1.1 in the manifest, in `n8n/config.yaml` and in the changelog. No `n8n-v1.1.1` tag exists and no GitHub release was created — the newest n8n tag is still `n8n-v1.1.0`.

Every `Release Please` run since then has stopped at the same place, so no application can be released at all, not only n8n. [Run 31823966404](https://github.com/kanso-labs/home-assistant-applications/actions/runs/31823966404) is the most recent:

```
✖ Bad pull request title: 'chore: release applications'
⚠ pullRequestTitlePattern miss the part of '${scope}'
⚠ pullRequestTitlePattern miss the part of '${component}'
⚠ pullRequestTitlePattern miss the part of '${version}'
...
❯ Found pull request #116: 'chore: release applications'
⚠ There are untagged, merged release PRs outstanding - aborting
```

The cause is in [`generateMatchPattern`](https://github.com/googleapis/release-please/blob/v17.6.0/src/util/pull-request-title.ts), which compiles the configured pattern straight into a regex and turns each placeholder into a named capture group — `${version}` becomes `v?(?<version>[0-9].*)`. A pattern with no placeholders compiles to a regex with no groups, so the parse returns nothing and no release is built. The merged pull request keeps its `autorelease: pending` label, and the outstanding-release guard then blocks every subsequent run.

The config schema does not catch this. `group-pull-request-title-pattern` is typed as a plain string, so a value that can never parse is accepted.

## Solution

`group-pull-request-title-pattern` is removed, restoring release-please's default. `release-please-config.json` is now byte-identical to what it was before [#111](https://github.com/kanso-labs/home-assistant-applications/pull/111).

The combined release pull request goes back to being titled `chore: release main`. That names the branch every release already targets and so tells the reader nothing, which is what [#111](https://github.com/kanso-labs/home-assistant-applications/pull/111) set out to improve — but the title is machine-read, and a better one has to keep `${version}` to stay parseable.

`AGENTS.md` records the trap and points at `src/util/pull-request-title.ts` as the thing to check, rather than the schema.

## After merging

[#116](https://github.com/kanso-labs/home-assistant-applications/pull/116) has already been retitled from `chore: release applications` to `chore: release main`, so the restored pattern can parse it. Merging this pushes `main`, which starts a `Release Please` run that should tag `n8n-v1.1.1`, move [#116](https://github.com/kanso-labs/home-assistant-applications/pull/116) to `autorelease: tagged`, and resume proposing releases.

Worth confirming after the run, since the queue stays blocked if it does not:

```shell
gh release list --repo kanso-labs/home-assistant-applications --limit 3
gh pr view 116 --repo kanso-labs/home-assistant-applications --json labels
```

## Test plan

**Verifiable by agent before merging**

- [x] Confirmed the mechanism in release-please v17.6.0's own source, the version the pinned action runs, rather than from the config schema
- [x] Confirmed `chore: release main` does parse: [#110](https://github.com/kanso-labs/home-assistant-applications/pull/110) carried that title and reached `autorelease: tagged`, cutting five tags
- [x] `release-please-config.json` diffs empty against its state before [#111](https://github.com/kanso-labs/home-assistant-applications/pull/111)
- [x] `./.github/scripts/verify-release-wiring.sh` passes
- [x] `npx prettier --check` passes on both files

**Cannot be verified before merge**

- [ ] Confirm `n8n-v1.1.1` is cut and the queue resumes — only a `Release Please` run can do it, and it triggers on `push` to `main`
